### PR TITLE
Add erlang images

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,0 +1,39 @@
+name: build erlang
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  push:
+    branches:
+      - master
+    paths:
+      - erlang/**
+jobs:
+  push:
+    name: "yolks:erlang_${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - 22
+          - 23
+          - 24
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        with:
+          version: "v0.5.1"
+          buildkitd-flags: --debug
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: ./erlang
+          file: ./erlang/${{ matrix.tag }}/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/pterodactyl/yolks:erlang_${{ matrix.tag }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ is tagged correctly.
   * `ghcr.io/parkervcp/yolks:alpine`
 * [`debian`](/oses/debian)
   * `ghcr.io/parkervcp/yolks:debian`
+* [`erlang`](/erlang)
+  * [`erlang22`](/erlang/22)
+    * `ghcr.io/parkervcp/yolks:erlang_22`
+  * [`erlang23`](/erlang/23)
+    * `ghcr.io/parkervcp/yolks:erlang_23`
+  * [`erlang24`](/erlang/24)
+    * `ghcr.io/parkervcp/yolks:erlang_24`
 * [`games`](/games)  
 	* [`arma3`](/games/arma3)
 	  * `ghcr.io/parkervcp/games:arma3`

--- a/erlang/22/Dockerfile
+++ b/erlang/22/Dockerfile
@@ -1,0 +1,16 @@
+FROM        --platform=$BUILDPLATFORM erlang:22-alpine
+
+LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
+
+LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.licenses=MIT
+
+RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata \
+				&& adduser -D -h /home/container container
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/ash", "/entrypoint.sh" ]

--- a/erlang/23/Dockerfile
+++ b/erlang/23/Dockerfile
@@ -1,0 +1,16 @@
+FROM        --platform=$BUILDPLATFORM erlang:23-alpine
+
+LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
+
+LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.licenses=MIT
+
+RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata \
+				&& adduser -D -h /home/container container
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/ash", "/entrypoint.sh" ]

--- a/erlang/24/Dockerfile
+++ b/erlang/24/Dockerfile
@@ -1,0 +1,16 @@
+FROM        --platform=$BUILDPLATFORM erlang:24-alpine
+
+LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
+
+LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.licenses=MIT
+
+RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata \
+				&& adduser -D -h /home/container container
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/ash", "/entrypoint.sh" ]

--- a/erlang/entrypoint.sh
+++ b/erlang/entrypoint.sh
@@ -1,0 +1,25 @@
+# Default the TZ environment variable to UTC.
+TZ=${TZ:-UTC}
+export TZ
+
+# Set environment variable that holds the Internal Docker IP
+INTERNAL_IP=$(ip route get 1 | awk '{print $NF;exit}')
+export INTERNAL_IP
+
+# Switch to the container's working directory
+cd /home/container || exit 1
+
+# Print Erlang's version
+printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0merl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'\n"
+erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
+
+# Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
+# variable format of "${VARIABLE}" before evaluating the string and automatically
+# replacing the values.
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+
+# Display the command we're running in the output, and then execute it with the env
+# from the container itself.
+printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0m%s\n" "$PARSED"
+# shellcheck disable=SC2086
+exec env ${PARSED}


### PR DESCRIPTION
### Description
This PR adds Alpine based Erlang images for Pterodactyl.

The available Erlang versions are the three newest versions:
- 22
- 23
- 24 (latest)

The content of the PR is based on the other generic language eggs like node and go and the already existing workflows to keep things consistent.

### Testing

- The build workflow can be compared to every existing one (like nodejs.yml or go.yml) and the image builds can be tested local with `docker buildx`
- Running a build image should output the installed Erlang version when no other entrypoint has been defined
- Running a build image and executing a shell (`ash`) should allow to run the "erl" command for an interactive Erlang shell.