### PR TITLE
Improve Cassandra images

### DIFF
--- a/cassandra/entrypoint.sh
+++ b/cassandra/entrypoint.sh
@@ -11,6 +11,11 @@ export INTERNAL_IP
 # Switch to the container's working directory
 cd /home/container || exit 1
 
+# Print Java version
+printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0mjava -version\n"
+java -version
+
+
 # Print Python version
 if command -v python &> /dev/null
 then

--- a/cassandra/java11_python3/Dockerfile
+++ b/cassandra/java11_python3/Dockerfile
@@ -5,7 +5,7 @@ LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache python3 ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache python3 py3-tz ca-certificates curl fontconfig git openssl sqlite tar tzdata \
 			    && adduser -D -h /home/container container
 
 USER        container

--- a/cassandra/java8_python2/Dockerfile
+++ b/cassandra/java8_python2/Dockerfile
@@ -6,6 +6,7 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache python2 ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+				&& python -m ensurepip --upgrade && pip install pytz \
 			    && adduser -D -h /home/container container
 
 USER        container


### PR DESCRIPTION
### Description
Add two improvements to the Cassandra images:
1. Print out the Java version provided by the image
2. Install pytz in the images (using pip for python2 image and apk install py3-tz for python 3) as it fixes a warning of CQLSH.

### Test
- Check if the images can be built sucessfully
- Check that the default entrypoints output contains the Java version
- Check that pytz is available in both images