### PR TITLE
[games] Add sleep to source image

### DIFF
--- a/games/source/entrypoint.sh
+++ b/games/source/entrypoint.sh
@@ -22,6 +22,9 @@
 # SOFTWARE.
 #
 
+# Wait for the container to fully initialize
+sleep 1
+
 # Default the TZ environment variable to UTC.
 TZ=${TZ:-UTC}
 export TZ


### PR DESCRIPTION
Adds a `sleep 1` command to the beginning of the entrypoint script to allow the container time to initialize and prevent race-condition issues, like with SteamCMD.

Current commit only affects the "source" image, but I can make a similar change to other images upon request.