### PR TITLE
ci(bots): ARM64 support and layer caching

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -26,6 +26,23 @@ jobs:
         with:
           version: "v0.5.1"
           buildkitd-flags: --debug
+      - name: Set up Docker Builder
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          install: true
+          endpoint: builders
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: arm64,amd64
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -35,7 +52,9 @@ jobs:
         with:
           context: ./bot/${{ matrix.tag }}
           file: ./bot/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
           push: true
           tags: |
             ghcr.io/parkervcp/yolks:bot_${{ matrix.tag }}

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -58,3 +58,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/parkervcp/yolks:bot_${{ matrix.tag }}
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -9,14 +9,13 @@ on:
     paths:
       - bot/**
 jobs:
-  push:
+  pushArm:
     name: "yolks:bot_${{ matrix.tag }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         tag:
-          - bastion
           - parkertron
           - red
           - sinusbot
@@ -24,14 +23,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
         with:
-          version: "v0.5.1"
+          version: "v0.7.0"
           buildkitd-flags: --debug
-      - name: Set up Docker Builder
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-          install: true
-          endpoint: builders
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
@@ -62,3 +55,31 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  pushAmd:
+    name: "yolks:bot_${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - bastion
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        with:
+          version: "v0.7.0"
+          buildkitd-flags: --debug
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: ./bot/${{ matrix.tag }}
+          file: ./bot/${{ matrix.tag }}/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/parkervcp/yolks:bot_${{ matrix.tag }}


### PR DESCRIPTION
* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
Yes, in this repo and also in parkervcp/eggs. But there is not any issue or PR to solve missing ARM64 builds. 

* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
Yes. Its Patch-1.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
Yes, it’s an addition for the build process to add support for arm64 images and a cache to speedup the build.