### PR TITLE
Update node.js dockerfile to include libtool

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,4 +41,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/Ethanadams642/yolks:nodejs_${{ matrix.tag }}
+            ghcr.io/ethanadams642/yolks:nodejs_${{ matrix.tag }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,4 +41,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/ethanadams642/yolks:nodejs_${{ matrix.tag }}
+            ghcr.io/parkervcp/yolks:nodejs_${{ matrix.tag }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,4 +41,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/parkervcp/yolks:nodejs_${{ matrix.tag }}
+            ghcr.io/Ethanadams642/yolks:nodejs_${{ matrix.tag }}

--- a/nodejs/12/Dockerfile
+++ b/nodejs/12/Dockerfile
@@ -3,7 +3,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH node:12-bullseye-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update \
-            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential \
+            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool \
             && npm -g install npm@latest \
             && useradd -m -d /home/container container
 

--- a/nodejs/14/Dockerfile
+++ b/nodejs/14/Dockerfile
@@ -3,7 +3,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH node:14-bullseye-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update \
-            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential \
+            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool \
             && npm -g install npm@latest \
             && useradd -m -d /home/container container
 

--- a/nodejs/15/Dockerfile
+++ b/nodejs/15/Dockerfile
@@ -3,7 +3,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH node:15-bullseye-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update \
-            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential \
+            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool \
             && npm -g install npm@latest \
             && useradd -m -d /home/container container
 

--- a/nodejs/16/Dockerfile
+++ b/nodejs/16/Dockerfile
@@ -3,7 +3,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH node:16-bullseye-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update \
-            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential \
+            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool \
             && npm -g install npm@latest \
             && useradd -m -d /home/container container
 

--- a/nodejs/17/Dockerfile
+++ b/nodejs/17/Dockerfile
@@ -3,7 +3,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH node:17-bullseye-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update \
-            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential \
+            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool \
             && npm -g install npm@latest \
             && useradd -m -d /home/container container
 


### PR DESCRIPTION
Hello, I have added libtool to the list of packages to be installed on all of the node.js dosckerfiles, it was a simple addition that i have tested on my pterodactyl instance, which functions as expected.

I feel that libtool should be added as myself and several other users have experienced issues when installing npm modules relating to libtool not being installed to compile a npm package.

This is my very first time contributing, so if i made a mistake or did something wrong please let me know so i can fix it.

Thanks!

P.S, the nodejs.yml file should not be merged as it was just for me to be able to build and test my files, and i am un sure weather i should have changed the file back to what is originally was.