### PR TITLE
Debian: downgrade liblua to 5.3

### DIFF
--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -20,14 +20,15 @@ RUN          apt update \
 ## Install dependencies
 RUN          apt install -y gcc g++ libgcc1 lib32gcc-s1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
              libfontconfig libicu67 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadbclient-dev-compat libduktape205 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
-             liblua5.4-0 libz-dev rapidjson-dev tzdata libevent-dev
+             liblua5.3-0 libz-dev rapidjson-dev tzdata libevent-dev
 
 ## Configure locale
 RUN          update-locale lang=en_US.UTF-8 \
              && dpkg-reconfigure --frontend noninteractive locales
-			 
+
 
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 CMD         [ "/bin/bash", "/entrypoint.sh" ]
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

It was upgraded to 5.4 when migrating to Yolks, but 5.3 is required for eggs such as beamng