### PR TITLE
feat(base_debian): remove lib32gcc-s1 for ARM support

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -21,6 +21,7 @@ jobs:
           - ubuntu
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
         with:
           version: "v0.5.1"
@@ -34,7 +35,7 @@ jobs:
         with:
           context: ./oses/${{ matrix.oses }}
           file: ./oses/${{ matrix.oses }}/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/parkervcp/yolks:${{ matrix.oses }}

--- a/oses/alpine/Dockerfile
+++ b/oses/alpine/Dockerfile
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-FROM        --platform=$BUILDPLATFORM alpine:latest
+FROM        --platform=$TARGETOS/$TARGETARCH alpine:latest
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -18,7 +18,7 @@ RUN          apt update \
              && apt upgrade -y
 
 ## Install dependencies
-RUN          apt install -y gcc g++ libgcc1 lib32gcc-s1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+RUN          apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
              libfontconfig libicu67 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadbclient-dev-compat libduktape205 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
              liblua5.3-0 libz-dev rapidjson-dev tzdata libevent-dev libzip4
 

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM         debian:bullseye-slim
+FROM         --platform=$TARGETOS/$TARGETARCH debian:bullseye-slim
 
 LABEL        author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/oses/ubuntu/Dockerfile
+++ b/oses/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ubuntu:18.04
+FROM  --platform=$TARGETOS/$TARGETARCH ubuntu:18.04
 
 LABEL author="Michael Parker" maintainer="parker@pterodactyl.io"
 
@@ -23,4 +23,4 @@ RUN   update-locale lang=en_US.UTF-8 \
 WORKDIR /home/container
 
 COPY  ./entrypoint.sh /entrypoint.sh
-CMD   ["/bin/bash", "/entrypoint.sh"]
+CMD   [ "/bin/bash", "/entrypoint.sh" ]

--- a/oses/ubuntu/Dockerfile
+++ b/oses/ubuntu/Dockerfile
@@ -9,16 +9,16 @@ RUN   useradd -m -d /home/container -s /bin/bash container
 
 ## update base packages
 RUN   apt update \
- &&   apt upgrade -y
+        &&   apt upgrade -y
 
 ## install dependencies
-RUN   apt install -y gcc g++ libgcc1 lib32gcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+RUN   apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
         libfontconfig libicu60 libiculx60 icu-devtools libunwind8 libssl1.0.0 libssl1.0-dev sqlite3 libsqlite3-dev libmariadbclient-dev libduktape202 libzip4 locales ffmpeg apt-transport-https init-system-helpers \
         libcurl3-gnutls libjsoncpp1 libleveldb1v5 liblua5.1-0 libluajit-5.1-2 libsqlite3-0 libfluidsynth1 bzip2 zlib1g libevent-dev
 
 ## configure locale
 RUN   update-locale lang=en_US.UTF-8 \
- &&   dpkg-reconfigure --frontend noninteractive locales
+        &&   dpkg-reconfigure --frontend noninteractive locales
 
 WORKDIR /home/container
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Remove steam-specific lib32gcc-s1 from the base image for multiarch support. Any images importing this base image can install it separately. Add multiarch support for base images allowing to run eggs like openrct, factorio, terraria, etc.