### PR TITLE
Update ALTV

### DIFF
--- a/games/altv/Dockerfile
+++ b/games/altv/Dockerfile
@@ -11,7 +11,7 @@ RUN     useradd -m -d /home/container -s /bin/bash container
 
 RUN     apt update -y \
         && apt upgrade -y \
-        && apt install -y gcc g++ libgcc-s1 lib32gcc-s1 gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+        && apt install -y g++ gcc libgcc-s1 lib32gcc-s1 gdb libstdc++6 libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
         libfontconfig1 libicu67 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev libduktape205 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata \
 		python3 dnsutils build-essential coreutils jq pcregrep
 


### PR DESCRIPTION
The image was broken , It spit out a error: `[09:00:13][Error] Error loading "libcsharp-module.so", Unix error: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: Version GLIBCXX_3.4.26 not found (required by /home/container/modules/libcsharp-module.so)`

I added  "libstdc++6" what include the GLIBCXX_3.4.26. I first build the image for myself to see if it works and it does:
![ZyEJ1l4](https://user-images.githubusercontent.com/67589015/158056023-d991d3f9-5034-48bb-900e-d56bcacad324.png)


### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
