### PR TITLE
add packages for mumble 1.4+

### DIFF
--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -20,13 +20,17 @@ RUN          apt update \
 ## Install dependencies
 RUN          apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
              libfontconfig libicu67 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadbclient-dev-compat libduktape205 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
-             liblua5.3-0 libz-dev rapidjson-dev tzdata libevent-dev libzip4
+             liblua5.3-0 libz-dev rapidjson-dev tzdata libevent-dev libzip4 libsybdb5 libodbc1 libavahi-compat-libdnssd1 libglib2.0-0
 
 ## Configure locale
 RUN          update-locale lang=en_US.UTF-8 \
              && dpkg-reconfigure --frontend noninteractive locales
 
-
+## install libmysqlclient21 for mumble 1.4+
+RUN         echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" >> /etc/apt/sources.list.d/unstable.list \
+            apt-get update \
+            apt -y install libmysqlclient21 
+           
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
 those packages are needed to run the mumble 1.4 + binary. I have to use the `http://ftp.us.debian.org/debian unstable main contrib non-free` repo because it needs libmysqlclient21. I wanted first to download the .deb file and use dpkg to install it but that will not work as this image is build for ARM and AMD and the .deb is only for 1 of the 2. 
