### PR TITLE
add wine staging + update mono and gecko version

### DIFF
--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         tag:
           - latest
+          - staging
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ is tagged correctly.
 
 * [`Wine`](/wine)
   * `ghcr.io/parkervcp/yolks:wine_latest`
+  * `ghcr.io/parkervcp/yolks:wine_staging`
 
 ### [Installation Images](/installers)
 

--- a/wine/entrypoint.sh
+++ b/wine/entrypoint.sh
@@ -48,11 +48,11 @@ if [[ $WINETRICKS_RUN =~ gecko ]]; then
         WINETRICKS_RUN=${WINETRICKS_RUN/gecko}
 
         if [ ! -f "$WINEPREFIX/gecko_x86.msi" ]; then
-                wget -q -O $WINEPREFIX/gecko_x86.msi http://dl.winehq.org/wine/wine-gecko/2.47.2/wine_gecko-2.47.2-x86.msi
+                wget -q -O $WINEPREFIX/gecko_x86.msi http://dl.winehq.org/wine/wine-gecko/2.47.3/wine_gecko-2.47.3-x86.msi
         fi
 
         if [ ! -f "$WINEPREFIX/gecko_x86_64.msi" ]; then
-                wget -q -O $WINEPREFIX/gecko_x86_64.msi http://dl.winehq.org/wine/wine-gecko/2.47.2/wine_gecko-2.47.2-x86_64.msi
+                wget -q -O $WINEPREFIX/gecko_x86_64.msi http://dl.winehq.org/wine/wine-gecko/2.47.3/wine_gecko-2.47.3-x86_64.msi
         fi
 
         wine msiexec /i $WINEPREFIX/gecko_x86.msi /qn /quiet /norestart /log $WINEPREFIX/gecko_x86_install.log
@@ -65,7 +65,7 @@ if [[ $WINETRICKS_RUN =~ mono ]]; then
         WINETRICKS_RUN=${WINETRICKS_RUN/mono}
 
         if [ ! -f "$WINEPREFIX/mono.msi" ]; then
-                wget -q -O $WINEPREFIX/mono.msi https://dl.winehq.org/wine/wine-mono/7.2.0/wine-mono-7.2.0-x86.msi
+                wget -q -O $WINEPREFIX/mono.msi https://dl.winehq.org/wine/wine-mono/7.3.0/wine-mono-7.3.0-x86.msi
         fi
 
         wine msiexec /i $WINEPREFIX/mono.msi /qn /quiet /norestart /log $WINEPREFIX/mono_install.log

--- a/wine/staging/Dockerfile
+++ b/wine/staging/Dockerfile
@@ -1,5 +1,5 @@
 # ---------------------------------------
-# Generic Wine image based on Wine stable 
+# Generic Wine image based on Wine staging 
 # ---------------------------------------
 FROM    ghcr.io/parkervcp/yolks:debian
 
@@ -17,7 +17,7 @@ RUN     wget -nc https://dl.winehq.org/wine-builds/winehq.key \
         && wget -O- -q download.opensuse.org/repositories/Emulators:/Wine:/Debian/Debian_11/Release.key | apt-key add - \
         && echo "deb http://download.opensuse.org/repositories/Emulators:/Wine:/Debian/Debian_11 ./" | tee /etc/apt/sources.list.d/wine-obs.list \
         && apt update \
-		&& apt install -y --install-recommends winehq-stable cabextract
+		&& apt install -y --install-recommends winehq-staging cabextract
 
 # Set up Winetricks
 RUN	    wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \


### PR DESCRIPTION
## Description

- add a wine staging image as some games: for example vrising bepinex need it.
- wine staging has over 100 + bug fixes so there is a good chance that some games will work with staging but not with stable.
- update the entrypoint.sh to use the latest mono and gecko versions.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [x] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
2. [x] Have you updated the README list to contain your new image?
