### PR TITLE
Remove unmaintand java images from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,10 @@ is tagged correctly.
 
 ### [Java](/java)
 
-* [`java7`](/java/7)
-  * `ghcr.io/parkervcp/yolks:java_7`
 * [`java8`](/java/8)
   * `ghcr.io/parkervcp/yolks:java_8`
-* [`java9`](/java/9)
-  * `ghcr.io/parkervcp/yolks:java_9`
 * [`java11`](/java/11)
-  * `ghcr.io/parkervcp/yolks:java_11`
-* [`java14`](/java/14)
-  * `ghcr.io/parkervcp/yolks:java_14`
+  * `ghcr.io/parkervcp/yolks:java_11``
 * [`java16`](/java/16)
   * `ghcr.io/parkervcp/yolks:java_16`
 * [`java17`](/java/17)


### PR DESCRIPTION
## Description

remove not more build java images  from the main readme

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
