### PR TITLE
add dotnet for arm64

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,7 @@ jobs:
           - 3.1
           - 5
           - 6
+          - 7
     steps:
       - uses: actions/checkout@v3
             # Setup QEMU for ARM64 Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,6 +22,8 @@ jobs:
           - 6
     steps:
       - uses: actions/checkout@v3
+            # Setup QEMU for ARM64 Build
+      - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v2
         with:
           version: "v0.8.2"
@@ -35,7 +37,7 @@ jobs:
         with:
           context: ./dotnet
           file: ./dotnet/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/parkervcp/yolks:dotnet_${{ matrix.tag }}

--- a/dotnet/2.1/Dockerfile
+++ b/dotnet/2.1/Dockerfile
@@ -9,7 +9,8 @@ RUN         apt update -y \
             && apt install -y apt-transport-https wget iproute2 libgdiplus \
             && wget https://dot.net/v1/dotnet-install.sh \   
             && chmod +x dotnet-install.sh \
-			&& ./dotnet-install.sh -i /usr/local/bin/ -v 2.1.818
+			&& ./dotnet-install.sh -i /usr/share -v 2.1.818 \
+            && ln -s /usr/share/dotnet /usr/bin/dotnet
 
 USER        container
 ENV         USER=container HOME=/home/container

--- a/dotnet/2.1/Dockerfile
+++ b/dotnet/2.1/Dockerfile
@@ -6,12 +6,10 @@ ENV         DEBIAN_FRONTEND noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \
-            && apt install -y apt-transport-https wget iproute2 \
-            && wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-            && dpkg -i packages-microsoft-prod.deb \
-            && rm packages-microsoft-prod.deb \
-            && apt update -y \
-            && apt install -y aspnetcore-runtime-2.1 libgdiplus
+            && apt install -y apt-transport-https wget iproute2 libgdiplus \
+            && wget https://dot.net/v1/dotnet-install.sh \   
+            && chmod +x dotnet-install.sh \
+			&& ./dotnet-install.sh -i /usr/local/bin/ -v 2.1.818
 
 USER        container
 ENV         USER=container HOME=/home/container

--- a/dotnet/3.1/Dockerfile
+++ b/dotnet/3.1/Dockerfile
@@ -6,13 +6,10 @@ ENV         DEBIAN_FRONTEND noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \
-            && apt install -y apt-transport-https wget iproute2 \
-            && wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-            && dpkg -i packages-microsoft-prod.deb \
-            && rm packages-microsoft-prod.deb \
-            && apt update -y \
-            && apt install -y aspnetcore-runtime-3.1 libgdiplus
-
+            && apt install -y apt-transport-https wget iproute2 libgdiplus \
+            && wget https://dot.net/v1/dotnet-install.sh \   
+            && chmod +x dotnet-install.sh \
+			&& ./dotnet-install.sh -i /usr/local/bin/ -v 3.1.424
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container

--- a/dotnet/3.1/Dockerfile
+++ b/dotnet/3.1/Dockerfile
@@ -9,7 +9,10 @@ RUN         apt update -y \
             && apt install -y apt-transport-https wget iproute2 libgdiplus \
             && wget https://dot.net/v1/dotnet-install.sh \   
             && chmod +x dotnet-install.sh \
-			&& ./dotnet-install.sh -i /usr/local/bin/ -v 3.1.424
+			&& ./dotnet-install.sh -i /usr/share -v 3.1.424 \
+            && ln -s /usr/share/dotnet /usr/bin/dotnet
+
+
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container

--- a/dotnet/3.1/Dockerfile
+++ b/dotnet/3.1/Dockerfile
@@ -9,7 +9,7 @@ RUN         apt update -y \
             && apt install -y apt-transport-https wget iproute2 libgdiplus \
             && wget https://dot.net/v1/dotnet-install.sh \   
             && chmod +x dotnet-install.sh \
-			&& ./dotnet-install.sh -i /usr/share -v 3.1.424 \
+			&& ./dotnet-install.sh -i /usr/share -v 3.1.425 \
             && ln -s /usr/share/dotnet /usr/bin/dotnet
 
 

--- a/dotnet/5/Dockerfile
+++ b/dotnet/5/Dockerfile
@@ -6,12 +6,10 @@ ENV         DEBIAN_FRONTEND noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \
-            && apt install -y apt-transport-https wget iproute2 \
-            && wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-            && dpkg -i packages-microsoft-prod.deb \
-            && rm packages-microsoft-prod.deb \
-            && apt update -y \
-            && apt install -y aspnetcore-runtime-5.0 libgdiplus
+            && apt install -y apt-transport-https wget iproute2 libgdiplus \
+            && wget https://dot.net/v1/dotnet-install.sh \   
+            && chmod +x dotnet-install.sh \
+			&& ./dotnet-install.sh -i /usr/local/bin/ -v 5.0.408
 
 USER        container
 ENV         USER=container HOME=/home/container

--- a/dotnet/5/Dockerfile
+++ b/dotnet/5/Dockerfile
@@ -9,7 +9,8 @@ RUN         apt update -y \
             && apt install -y apt-transport-https wget iproute2 libgdiplus \
             && wget https://dot.net/v1/dotnet-install.sh \   
             && chmod +x dotnet-install.sh \
-			&& ./dotnet-install.sh -i /usr/local/bin/ -v 5.0.408
+			&& ./dotnet-install.sh -i /usr/share -v 5.0.408 \
+            && ln -s /usr/share/dotnet /usr/bin/dotnet
 
 USER        container
 ENV         USER=container HOME=/home/container

--- a/dotnet/6/Dockerfile
+++ b/dotnet/6/Dockerfile
@@ -6,12 +6,10 @@ ENV         DEBIAN_FRONTEND noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \
-            && apt install -y apt-transport-https wget iproute2 \
-            && wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-            && dpkg -i packages-microsoft-prod.deb \
-            && rm packages-microsoft-prod.deb \
-            && apt update -y \
-            && apt install -y aspnetcore-runtime-6.0 libgdiplus
+            && apt install -y apt-transport-https wget iproute2 libgdiplus \
+            && wget https://dot.net/v1/dotnet-install.sh \   
+            && chmod +x dotnet-install.sh \
+			&& ./dotnet-install.sh -i /usr/local/bin/
 
 USER        container
 ENV         USER=container HOME=/home/container

--- a/dotnet/6/Dockerfile
+++ b/dotnet/6/Dockerfile
@@ -9,7 +9,8 @@ RUN         apt update -y \
             && apt install -y apt-transport-https wget iproute2 libgdiplus \
             && wget https://dot.net/v1/dotnet-install.sh \   
             && chmod +x dotnet-install.sh \
-			&& ./dotnet-install.sh -i /usr/local/bin/
+			&& ./dotnet-install.sh -i /usr/share \
+            && ln -s /usr/share/dotnet /usr/bin/dotnet
 
 USER        container
 ENV         USER=container HOME=/home/container

--- a/dotnet/6/Dockerfile
+++ b/dotnet/6/Dockerfile
@@ -9,7 +9,7 @@ RUN         apt update -y \
             && apt install -y apt-transport-https wget iproute2 libgdiplus \
             && wget https://dot.net/v1/dotnet-install.sh \   
             && chmod +x dotnet-install.sh \
-			&& ./dotnet-install.sh -i /usr/share \
+			&& ./dotnet-install.sh -i /usr/share -v 6.0.403 \
             && ln -s /usr/share/dotnet /usr/bin/dotnet
 
 USER        container

--- a/dotnet/7/Dockerfile
+++ b/dotnet/7/Dockerfile
@@ -9,7 +9,7 @@ RUN         apt update -y \
             && apt install -y apt-transport-https wget iproute2 libgdiplus \
             && wget https://dot.net/v1/dotnet-install.sh \   
             && chmod +x dotnet-install.sh \
-			      && ./dotnet-install.sh -i /usr/share -v 7.0.100 \
+			&& ./dotnet-install.sh -i /usr/share -v 7.0.100 \
             && ln -s /usr/share/dotnet /usr/bin/dotnet
 
 USER        container

--- a/dotnet/7/Dockerfile
+++ b/dotnet/7/Dockerfile
@@ -1,0 +1,20 @@
+FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
+
+LABEL       author="Torsten Widmann" maintainer="info@goover.de"
+
+ENV         DEBIAN_FRONTEND noninteractive
+
+RUN         apt update -y \
+            && apt upgrade -y \
+            && apt install -y apt-transport-https wget iproute2 libgdiplus \
+            && wget https://dot.net/v1/dotnet-install.sh \   
+            && chmod +x dotnet-install.sh \
+			&& ./dotnet-install.sh -i /usr/share -v 7.0.100 \
+            && ln -s /usr/share/dotnet /usr/bin/dotnet
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/dotnet/entrypoint.sh
+++ b/dotnet/entrypoint.sh
@@ -5,6 +5,9 @@ cd /home/container
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
 
+# set this variable, dotnet needs it even without it it reports to `dotnet --info` it can not start any aplication without this
+export DOTNET_ROOT=/usr/share/
+
 # Replace Startup Variables
 MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 echo -e ":/home/container$ ${MODIFIED_STARTUP}"


### PR DESCRIPTION
## Description

This PR moves the dotnet installing from the .deb file to the official dotnet install script. What auto-detects arm64 and amd64
Example run with my test image: https://github.com/QuintenQVD0/yolks/actions/runs/3404735771/jobs/5662191602 The binary get stored in /usr/local/bin/ what is in PATH

edit:
note: that this image will now include also sdk and not just the runtime anymore

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?


### New Image Submissions:

1. [x] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
2. [x] Have you updated the README list to contain your new image?
