### PR TITLE
mono: replace lib32gcc-s1 with lib32gcc-s1-amd64-cross to support arm64

### DIFF
--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -19,6 +19,7 @@ jobs:
           - latest
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v2
         with:
           version: "v0.8.2"
@@ -32,7 +33,7 @@ jobs:
         with:
           context: ./mono
           file: ./mono/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/parkervcp/yolks:mono_${{ matrix.tag }}

--- a/mono/latest/Dockerfile
+++ b/mono/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM        ghcr.io/parkervcp/yolks:debian
+FROM         --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="support@goover.de"
 
@@ -8,7 +8,7 @@ RUN         apt install -y fontconfig dirmngr
 RUN         apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN         sh -c 'echo "deb https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list'
 RUN         apt update
-RUN         apt install -y mono-complete lib32gcc-s1
+RUN         apt install -y mono-complete lib32gcc-s1-amd64-cross
 
 USER        container
 ENV         USER=container HOME=/home/container


### PR DESCRIPTION
## Description

Replace lib32gcc-s1 with lib32gcc-s1-amd64-cross to support arm64 build.
![afbeelding](https://user-images.githubusercontent.com/67589015/201485726-a66f356f-fa8b-4013-a4b7-bc6c9f2c18cf.png)
![afbeelding](https://user-images.githubusercontent.com/67589015/201485731-2a494606-ba84-4f5d-9baf-5c5331f86d9c.png)


### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->
