### PR TITLE
[Arma 3] Fix SteamCMD Crashing (Debian Edition)

### DIFF
--- a/games/arma3/Dockerfile
+++ b/games/arma3/Dockerfile
@@ -17,6 +17,7 @@ RUN         dpkg --add-architecture i386 \
                 iproute2 \
                 gettext-base \
                 ca-certificates \
+				numactl \
                 libssl-dev \
                 lib32gcc-s1 \
                 libsdl2-2.0-0 \

--- a/games/arma3/entrypoint.sh
+++ b/games/arma3/entrypoint.sh
@@ -3,7 +3,7 @@
 ## File: Pterodactyl Arma 3 Image - entrypoint.sh
 ## Author: David Wolfe (Red-Thirten)
 ## Contributors: Aussie Server Hosts (https://aussieserverhosts.com/), Stephen White (SilK)
-## Date: 2022/05/22
+## Date: 2022/11/26
 ## License: MIT License
 
 ## === CONSTANTS ===
@@ -46,14 +46,14 @@ function RunSteamCMD { #[Input: int server=0 mod=1 optional_mod=2; int id]
 
         # Check if updating server or mod
         if [[ $1 == 0 ]]; then # Server
-            ${STEAMCMD_DIR}/steamcmd.sh +force_install_dir /home/container "+login \"${STEAM_USER}\" \"${STEAM_PASS}\"" +app_update $2 $extraFlags $validateServer +quit | tee -a "${STEAMCMD_LOG}"
+            numactl --physcpubind=+0 ${STEAMCMD_DIR}/steamcmd.sh +force_install_dir /home/container "+login \"${STEAM_USER}\" \"${STEAM_PASS}\"" +app_update $2 $extraFlags $validateServer +quit | tee -a "${STEAMCMD_LOG}"
         else # Mod
-            ${STEAMCMD_DIR}/steamcmd.sh "+login \"${STEAM_USER}\" \"${STEAM_PASS}\"" +workshop_download_item $GAME_ID $2 +quit | tee -a "${STEAMCMD_LOG}"
+            numactl --physcpubind=+0 ${STEAMCMD_DIR}/steamcmd.sh "+login \"${STEAM_USER}\" \"${STEAM_PASS}\"" +workshop_download_item $GAME_ID $2 +quit | tee -a "${STEAMCMD_LOG}"
         fi
 
         # Error checking for SteamCMD
         steamcmdExitCode=${PIPESTATUS[0]}
-        if [[ -n $(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL") ]]; then # Catch errors (ignore setlocale and SDL warnings)
+        if [[ -n $(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|thread") ]]; then # Catch errors (ignore setlocale, SDL, and thread priority warnings)
             # Soft errors
             if [[ -n $(grep -i "Timeout downloading item" "${STEAMCMD_LOG}") ]]; then # Mod download timeout
                 echo -e "\n${YELLOW}[UPDATE]: ${NC}Timeout downloading Steam Workshop mod: \"${CYAN}${modName}${NC}\" (${CYAN}${2}${NC})"
@@ -96,6 +96,7 @@ function RunSteamCMD { #[Input: int server=0 mod=1 optional_mod=2; int id]
         elif [[ $steamcmdExitCode != 0 ]]; then # Unknown fatal error
             echo -e "\n${RED}[UPDATE]: SteamCMD has crashed for an unknown reason!${NC} (Exit code: ${CYAN}${steamcmdExitCode}${NC})"
             echo -e "\t${YELLOW}(Please contact your administrator/host for support)${NC}\n"
+            cp -r /tmp/dumps /home/container/dumps
             exit $steamcmdExitCode
         else # Success!
             if [[ $1 == 0 ]]; then # Server
@@ -220,7 +221,7 @@ allMods=$(echo $allMods | sed -e 's/;/ /g') # Convert from string to array
 # Update everything (server and mods), if specified
 if [[ ${UPDATE_SERVER} == 1 ]]; then
     echo -e "\n${GREEN}[STARTUP]: ${CYAN}Starting checks for all updates...${NC}"
-    echo -e "(It is okay to ignore any \"SDL\" errors during this process)\n"
+    echo -e "(It is okay to ignore any \"SDL\" and \"thread priority\" errors during this process)\n"
 
     ## Update game server
     echo -e "${GREEN}[UPDATE]:${NC} Checking for game server updates with App ID: ${CYAN}${STEAMCMD_APPID}${NC}..."


### PR DESCRIPTION
## Description

Supersedes #99 and partially resolves https://github.com/parkervcp/eggs/issues/1965 by addressing said issue present in the Arma 3 yolk.

Currently, SteamCMD crashes with exit code 139 when using a real account to log in on Debian-based images used with Pterodactyl. We know this issue does not occur for the following scenarios:
- Logging in with the "anonymous" user
- Running SteamCMD on Ubuntu
- Running SteamCMD pinned to a single CPU

We can't log in with "anonymous" for Arma, and we'd rather not move to Ubuntu. That leaves pinning SteamCMD to a single CPU as the current best solution, which this PR aims to provide.

The image is currently live for testing purposes here if you would like:
`ghcr.io/lilkingjr1/arma3-yolk:debian`

#### Extra Info:
It is currently unknown for sure why SteamCMD crashes for this particular set of circumstances, and this PR just aims to resolve the issue with what works. Exit code [139 is likely caused by a SIGSEGV signal](https://www.containiq.com/post/sigsegv-segmentation-fault-linux-containers-exit-code-139#:~:text=When%20a%20container%20exits%20with,are%20terminating%20with%20code%20139.) raised by the Debian operating system because it thinks SteamCMD is making an integrity violation. This violation is possibly caused by SteamCMD trying to set/determine thread priority on multiple CPUs, but it can't properly negotiate this check with the OS (either due to `libSDL` typically not being loaded properly, or some other reason). This is implied with warning errors SteamCMD produces when it does actually run (either on Ubuntu or on one thread in Debian). If a solution to this CPU/thread issue can be found in the future for Debian, `numactl` can be removed.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
