### PR TITLE
[Arma 3] Hot Fix SteamCMD Intermittently Failing Workshop Downloads

### DIFF
--- a/games/arma3/Dockerfile
+++ b/games/arma3/Dockerfile
@@ -17,7 +17,7 @@ RUN         dpkg --add-architecture i386 \
                 iproute2 \
                 gettext-base \
                 ca-certificates \
-				numactl \
+                numactl \
                 libssl-dev \
                 lib32gcc-s1 \
                 libsdl2-2.0-0 \

--- a/games/arma3/entrypoint.sh
+++ b/games/arma3/entrypoint.sh
@@ -8,6 +8,7 @@
 
 ## === CONSTANTS ===
 STEAMCMD_DIR="./steamcmd"                       # SteamCMD's directory containing steamcmd.sh
+WORKSHOP_DIR="./Steam/steamapps/workshop"       # SteamCMD's directory containing workshop downloads
 STEAMCMD_LOG="${STEAMCMD_DIR}/steamcmd.log"     # Log file for SteamCMD
 GAME_ID=107410                                  # SteamCMD ID for the Arma 3 GAME (not server). Only used for Workshop mod downloads.
 EGG_URL='https://github.com/parkervcp/eggs/tree/master/game_eggs/steamcmd_servers/arma/arma3'   # URL for Pterodactyl Egg & Info (only used as info to legacy users)
@@ -105,8 +106,8 @@ function RunSteamCMD { #[Input: int server=0 mod=1 optional_mod=2; int id]
                 # Move the downloaded mod to the root directory, and replace existing mod if needed
                 mkdir -p ./@$2
                 rm -rf ./@$2/*
-                mv -f ./Steam/steamapps/workshop/content/$GAME_ID/$2/* ./@$2
-                rm -d ./Steam/steamapps/workshop/content/$GAME_ID/$2
+                mv -f ${WORKSHOP_DIR}/content/$GAME_ID/$2/* ./@$2
+                rm -d ${WORKSHOP_DIR}/content/$GAME_ID/$2
                 # Make the mods contents all lowercase
                 ModsLowercase @$2
                 # Move any .bikey's to the keys directory
@@ -282,8 +283,12 @@ if [[ ${UPDATE_SERVER} == 1 ]]; then
                     if [[ -n $latestUpdate ]] && [[ $latestUpdate =~ ^[0-9]+$ ]]; then # Notify last update date, if valid
                         echo -e "\tMod was last updated: ${CYAN}$(date -d @${latestUpdate})${NC}"
                     fi
+                    
+                    # Delete SteamCMD appworkshop cache before running to avoid mod download failures
+                    echo -e "\tClearing SteamCMD appworkshop cache..."
+                    rm -f ${WORKSHOP_DIR}/appworkshop_$GAME_ID.acf
+                    
                     echo -e "\tAttempting mod update/download via SteamCMD...\n"
-
                     RunSteamCMD $modType $modID
                 fi
             fi


### PR DESCRIPTION
## Description

Fixes current issue where SteamCMD will intermittently present a "Failure" error when downloading Workshop mods due to a corrupt cache file. This hot fix simply deletes the `appworkshop_107410.acf` cache file before every SteamCMD run for mods.

The image is currently live for testing purposes here if you would like:
`ghcr.io/lilkingjr1/arma3-yolk:main`

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
