### PR TITLE
Fix packervcp/eggs issue #1389 DayZ: Drop 'sort -u' to retain user specified mod load order

### DIFF
--- a/games/dayz/entrypoint.sh
+++ b/games/dayz/entrypoint.sh
@@ -145,7 +145,7 @@ function ModsLowercase {
 # Removes duplicate items from a semicolon delimited string
 function RemoveDuplicates { #[Input: str - Output: printf of new str]
     if [[ -n $1 ]]; then # If nothing to compare, skip to prevent extra semicolon being returned
-        echo $1 | sed -e 's/;/\n/g' | sort -u | xargs printf '%s;'
+        echo $1 | sed -e 's/;/\n/g' | xargs printf '%s;'
     fi
 }
 


### PR DESCRIPTION
## Description

Fixes the mod list load order for the DayZ server. A function called `RemoveDuplicates` found in the Docker entrypoint script, uses `sort -u`. Which re-orders the mods and can cause the server to produce an error as mod dependencies have not be loaded in the correct order.

This changes removes `sort -u`.