### PR TITLE
Update ubuntu to 22.04

### DIFF
--- a/oses/ubuntu/Dockerfile
+++ b/oses/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM  --platform=$TARGETOS/$TARGETARCH ubuntu:18.04
+FROM  --platform=$TARGETOS/$TARGETARCH ubuntu:22.04
 
 LABEL author="Michael Parker" maintainer="parker@pterodactyl.io"
 
@@ -13,8 +13,8 @@ RUN   apt update \
 
 ## install dependencies
 RUN   apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
-        libfontconfig libicu60 libiculx60 icu-devtools libunwind8 libssl1.0.0 libssl1.0-dev sqlite3 libsqlite3-dev libmariadbclient-dev libduktape202 libzip4 locales ffmpeg apt-transport-https init-system-helpers \
-        libcurl3-gnutls libjsoncpp1 libleveldb1v5 liblua5.1-0 libluajit-5.1-2 libsqlite3-0 libfluidsynth1 bzip2 zlib1g libevent-dev
+        libfontconfig icu-devtools libunwind8 sqlite3 libsqlite3-dev libzip4 locales ffmpeg apt-transport-https init-system-helpers \
+        libcurl3-gnutls liblua5.1-0 libluajit-5.1-2 libsqlite3-0 bzip2 zlib1g libevent-dev libmariadb-dev-compat libmariadb-dev libssl-dev libfluidsynth-dev libmariadb-dev libicu-dev libssl3 libduktape207 libjsoncpp-dev libleveldb1d
 
 ## configure locale
 RUN   update-locale lang=en_US.UTF-8 \

--- a/oses/ubuntu/Dockerfile
+++ b/oses/ubuntu/Dockerfile
@@ -14,7 +14,8 @@ RUN   apt update \
 ## install dependencies
 RUN   apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
         libfontconfig icu-devtools libunwind8 sqlite3 libsqlite3-dev libzip4 locales ffmpeg apt-transport-https init-system-helpers \
-        libcurl3-gnutls liblua5.1-0 libluajit-5.1-2 libsqlite3-0 bzip2 zlib1g libevent-dev libmariadb-dev-compat libmariadb-dev libssl-dev libfluidsynth-dev libmariadb-dev libicu-dev libssl3 libduktape207 libjsoncpp-dev libleveldb1d
+        libcurl3-gnutls liblua5.1-0 libluajit-5.1-2 libsqlite3-0 bzip2 zlib1g libevent-dev libmariadb-dev-compat libmariadb-dev libssl-dev \
+		libfluidsynth-dev libmariadb-dev libicu-dev libssl3 libduktape207 libjsoncpp-dev libleveldb1d libncurses5 libncursesw5
 
 ## configure locale
 RUN   update-locale lang=en_US.UTF-8 \


### PR DESCRIPTION
## Description

This resloves a issue as libc6 for debian is currently at version  2.31 and some aplication need GLIBC_2.34 like quake3e where I am making a egg for. debian does not yet support this but ubuntu does but only in the 22 release. This PR update the image to 22.04 and replace needed packages

libssl1.0-dev --> libssl-dev
libfluidsynth1 --> libfluidsynth-dev
libmariadbclient-dev --> libmariadb-dev
libicu60 and libiculx60 --> libicu-dev
libssl1.0.0 --> libssl3
libduktape202 --> libduktape207 
libjsoncpp1 --> libjsoncpp-dev
libleveldb1v5 --> libleveldb1d

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

