### PR TITLE
bastion: move to mongodb6 + python2 -> 3 + set mongodb to use always use the same log file + build for arm64

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -19,6 +19,7 @@ jobs:
           - parkertron
           - red
           - sinusbot
+          - bastion
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
@@ -56,30 +57,30 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  pushAmd:
-    name: "yolks:bot_${{ matrix.tag }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - bastion
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v1
-        with:
-          version: "v0.7.0"
-          buildkitd-flags: --debug
-      - uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
-        with:
-          context: ./bot/${{ matrix.tag }}
-          file: ./bot/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/parkervcp/yolks:bot_${{ matrix.tag }}
+  # pushAmd:
+  #   name: "yolks:bot_${{ matrix.tag }}"
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       tag:
+  #         - bastion
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: docker/setup-buildx-action@v1
+  #       with:
+  #         version: "v0.7.0"
+  #         buildkitd-flags: --debug
+  #     - uses: docker/login-action@v1
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.REGISTRY_TOKEN }}
+  #     - uses: docker/build-push-action@v2
+  #       with:
+  #         context: ./bot/${{ matrix.tag }}
+  #         file: ./bot/${{ matrix.tag }}/Dockerfile
+  #         platforms: linux/amd64
+  #         push: true
+  #         tags: |
+  #           ghcr.io/parkervcp/yolks:bot_${{ matrix.tag }}

--- a/bot/bastion/Dockerfile
+++ b/bot/bastion/Dockerfile
@@ -1,15 +1,14 @@
-FROM        --platform=$TARGETOS/$TARGETARCH node:18-bullseye
+FROM        --platform=$TARGETOS/$TARGETARCH mongo:6-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-## install mongo
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | apt-key add - \
- && echo "deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
- && apt update \
- && apt install -y mongodb-org mongodb-org-server mongodb-org-shell mongodb-org-mongos mongodb-org-tools \
- ## install bastion reqs
- && apt install -y python3 build-essential git libtool netcat ffmpeg iproute2 curl tzdata \
+## install nodejs 18
+RUN apt update && apt install --no-install-recommends -y curl \ 
+ && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+ && apt install -y nodejs \
  && npm install -g npm@latest \
+ ## install bastion reqs
+ && apt install -y python3 build-essential git libtool netcat ffmpeg iproute2 tzdata \
  ## add container user
  && useradd -d /home/container -m container -s /bin/bash
 

--- a/bot/bastion/Dockerfile
+++ b/bot/bastion/Dockerfile
@@ -3,12 +3,12 @@ FROM        --platform=$TARGETOS/$TARGETARCH node:18-bullseye
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 ## install mongo
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
- && echo "deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/5.0 main" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | apt-key add - \
+ && echo "deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
  && apt update \
  && apt install -y mongodb-org mongodb-org-server mongodb-org-shell mongodb-org-mongos mongodb-org-tools \
  ## install bastion reqs
- && apt install -y python build-essential git libtool netcat ffmpeg iproute2 curl tzdata \
+ && apt install -y python3 build-essential git libtool netcat ffmpeg iproute2 curl tzdata \
  ## add container user
  && useradd -d /home/container -m container -s /bin/bash
 

--- a/bot/bastion/Dockerfile
+++ b/bot/bastion/Dockerfile
@@ -9,6 +9,7 @@ RUN wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | apt-key add -
  && apt install -y mongodb-org mongodb-org-server mongodb-org-shell mongodb-org-mongos mongodb-org-tools \
  ## install bastion reqs
  && apt install -y python3 build-essential git libtool netcat ffmpeg iproute2 curl tzdata \
+ && npm install -g npm@latest \
  ## add container user
  && useradd -d /home/container -m container -s /bin/bash
 

--- a/bot/bastion/entrypoint.sh
+++ b/bot/bastion/entrypoint.sh
@@ -10,10 +10,10 @@ MODIFIED_STARTUP=$(echo -e $(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/
 echo -e ":/home/container$ ${MODIFIED_STARTUP}"
 
 # start mongo
-mongod --fork --dbpath /home/container/mongodb/ --port 27017 --logpath /home/container/mongod.log && until nc -z -v -w5 127.0.0.1 27017; do echo 'Waiting for mongodb connection...'; sleep 5; done
+mongod --fork --dbpath /home/container/mongodb/ --port 27017 --logpath /home/container/mongod.log --logRotate reopen --logappend && until nc -z -v -w5 127.0.0.1 27017; do echo 'Waiting for mongodb connection...'; sleep 5; done
 
 # Run the Server
 eval ${MODIFIED_STARTUP}
 
 # stop mongo
-mongo --eval \"db.getSiblingDB('admin').shutdownServer()\
+mongo --eval "db.getSiblingDB('admin').shutdownServer()"

--- a/bot/bastion/entrypoint.sh
+++ b/bot/bastion/entrypoint.sh
@@ -39,4 +39,4 @@ echo -e "${BLUE}-------------------------------------------------${NC}"
 eval ${MODIFIED_STARTUP}
 
 # stop mongo
-mongo --eval "db.getSiblingDB('admin').shutdownServer()"
+mongod --eval "db.adminCommand({ "shutdown" : 1 })"

--- a/bot/bastion/entrypoint.sh
+++ b/bot/bastion/entrypoint.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#Variables
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+clear
+#show versions
+echo -e "${BLUE}-------------------------------------------------${NC}"
+echo -e "${YELLOW}BastionBot Installation${NC}"
+echo -e "${BLUE}-------------------------------------------------${NC}"
+echo -e "${YELLOW}MongoDB Version:${NC} " && mongod --version
+echo -e "${YELLOW}NodeJS Version:${NC} " && node -v
+echo -e "${YELLOW}Python Version:${NC} " && python3 --version
+echo -e "${BLUE}-------------------------------------------------${NC}"
+
 cd /home/container
 
 # Set environment variable that holds the Internal Docker IP
@@ -7,12 +24,18 @@ export INTERNAL_IP
 
 # Replace Startup Variables
 MODIFIED_STARTUP=$(echo -e $(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g'))
-echo -e ":/home/container$ ${MODIFIED_STARTUP}"
+echo -e "${YELLOW}:/home/container${NC} ${MODIFIED_STARTUP}"
 
 # start mongo
+echo -e "${BLUE}-------------------------------------------------${NC}"
+echo -e "${YELLOW}starting MongoDB...${NC}"
+echo -e "${BLUE}-------------------------------------------------${NC}"
 mongod --fork --dbpath /home/container/mongodb/ --port 27017 --logpath /home/container/mongod.log --logRotate reopen --logappend && until nc -z -v -w5 127.0.0.1 27017; do echo 'Waiting for mongodb connection...'; sleep 5; done
 
 # Run the Server
+echo -e "${BLUE}-------------------------------------------------${NC}"
+echo -e "${YELLOW}BastionBot starting...${NC}"
+echo -e "${BLUE}-------------------------------------------------${NC}"
 eval ${MODIFIED_STARTUP}
 
 # stop mongo


### PR DESCRIPTION
## Description

- Move to mongoDB 6 as it is longer supported and recommended to use
- change the mongodb startup cmd to always use the same log file so the root dir is not full of logs
- move to python3 
- remove the escaping around the mongo stop cmd as the it is in "" so it is not needed
- update entrypoint with some prity version prints

should look something like this: but with no npm version print
![image](https://user-images.githubusercontent.com/67589015/208293114-ab8ba34b-74f5-4be4-a339-8773d4a73728.png)

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
