### PR TITLE
Allow graceful shutdowns for DayZ Server

### DIFF
--- a/games/dayz/entrypoint.sh
+++ b/games/dayz/entrypoint.sh
@@ -272,12 +272,12 @@ envsubst < /passwd.template > ${NSS_WRAPPER_PASSWD}
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
 
 # Replace Startup Variables
-modifiedStartup=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+modifiedStartup=`exec env echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 
 # Start the Server
 echo -e "\n${GREEN}[STARTUP]:${NC} Starting server with the following startup command:"
 echo -e "${CYAN}${modifiedStartup}${NC}\n"
-exec env ${modifiedStartup}
+${modifiedStartup}
 
 if [ $? -ne 0 ]; then
     echo -e "\n${RED}PTDL_CONTAINER_ERR: There was an error while attempting to run the start command.${NC}\n"

--- a/games/dayz/entrypoint.sh
+++ b/games/dayz/entrypoint.sh
@@ -277,7 +277,7 @@ modifiedStartup=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 # Start the Server
 echo -e "\n${GREEN}[STARTUP]:${NC} Starting server with the following startup command:"
 echo -e "${CYAN}${modifiedStartup}${NC}\n"
-${modifiedStartup}
+exec env ${modifiedStartup}
 
 if [ $? -ne 0 ]; then
     echo -e "\n${RED}PTDL_CONTAINER_ERR: There was an error while attempting to run the start command.${NC}\n"


### PR DESCRIPTION
## Description
Currently, an attempt to stop server created using DayZ (Experimental) egg does nothing and the only way to stop it is to kill it. This change allows to [correctly pass a SIGINT](https://github.com/pterodactyl/panel/issues/3679) and gracefully stop it.

[Tested](https://github.com/Moondarker/yolks/pkgs/container/games) to be working correctly with [this PR](https://github.com/parkervcp/eggs/pull/2021)

@lilkingjr1, his can also be applied to ArmA 3 yolk and some others with the same problem

### All Submissions:

* [X] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [X] Have you created a new branch for your changes and PR from that branch and not from your master branch?