### PR TITLE
feat(java): Replace openjdk with termium images

### DIFF
--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:11-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11.0.13_8-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
@@ -6,7 +6,7 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -1,9 +1,9 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-11-jdk
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk11-openj9:debianslim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:16-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
@@ -6,7 +6,7 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk16-openj9:debianslim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -1,9 +1,9 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-16-jdk
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-focal
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
@@ -6,7 +6,7 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:17-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -6,7 +6,7 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:19-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:19-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -6,7 +6,7 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:8-slim-buster
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8u312-b07-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -1,4 +1,4 @@
-FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk8-openj9:debianslim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11.0.13_8-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -1,9 +1,9 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11.0.13_8-jdk-focal
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-8-jdk
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update -y \
-						&& apt install -y curl ca-certificates openssl git tar sqlite fontconfig tzdata iproute2 libfreetype6 \
+						&& apt install -y curl lsof ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 libfreetype6 \
 						&& useradd -d /home/container -m container
 
 USER        container


### PR DESCRIPTION
## Description

- OpenJDK Docker images have been completely deprecated move to eclipse-temurin and ibm-semeru-runtimes
- add lsof

same as: https://github.com/pterodactyl/yolks/pull/34
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
