### PR TITLE
removed version pinning from BuildKit in github actions

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/box64.yml
+++ b/.github/workflows/box64.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2          
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2          
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/steamcmd.yml
+++ b/.github/workflows/steamcmd.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/voice.yml
+++ b/.github/workflows/voice.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:


### PR DESCRIPTION
## Description

removed version pinning from Buildkit, to use always the latest version, insteed a pinned version.

`Buildkit:  v0.11.2`

This fixes per example:

`buildx failed with: ERROR: failed to solve: failed to push ghcr.io/parkervcp/yolks:wine_latest: failed to copy: io: read/write on closed pipe`



