### PR TITLE
feat(installers): add wget package to debian

### DIFF
--- a/installers/debian/Dockerfile
+++ b/installers/debian/Dockerfile
@@ -32,4 +32,4 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
 				&& apt update \
 				&& apt upgrade -y \
-				&& apt -y --no-install-recommends install ca-certificates curl lib32gcc-s1 libsdl2-2.0-0:i386 git unzip zip tar jq
+				&& apt -y --no-install-recommends install ca-certificates curl lib32gcc-s1 libsdl2-2.0-0:i386 git unzip zip tar jq wget


### PR DESCRIPTION
## Description

- add wget to the debian installer image as sometimes it is preferd over curl and then `apt update` and `apt install...` is not needed in the install script and it will speed up install times

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
