### PR TITLE
[Arma 3] Fix Bookworm specific packages

### DIFF
--- a/games/arma3/Dockerfile
+++ b/games/arma3/Dockerfile
@@ -27,8 +27,8 @@ RUN         dpkg --add-architecture i386 \
                 lib32stdc++6 \
                 libnss-wrapper \
                 libnss-wrapper:i386 \
-                libtbbmalloc2 \
-                libtbbmalloc2:i386
+                libtbb2 \
+                libtbb2:i386
 
 ## Configure locale
 RUN         update-locale lang=en_US.UTF-8 \


### PR DESCRIPTION
## Description

If we are going to lock the base image to Bullseye, we need to put the original libtbb2 packages back.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?