### PR TITLE
OS_Debian: add libstdc++6

### DIFF
--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -20,7 +20,7 @@ RUN          apt update \
 ## Install dependencies
 RUN          apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
              libfontconfig libicu67 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadbclient-dev-compat libduktape205 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
-             liblua5.3-0 libz-dev rapidjson-dev tzdata libevent-dev libzip4 libprotobuf23 libfluidsynth2 procps
+             liblua5.3-0 libz-dev rapidjson-dev tzdata libevent-dev libzip4 libprotobuf23 libfluidsynth2 procps libstdc++6
 
 ## Configure locale
 RUN          update-locale lang=en_US.UTF-8 \


### PR DESCRIPTION
## Description

For fivem add libstdc++6 as it apprently is needed now

```
Error loading shared library libstdc++.so.6: No such file or directory (needed by /home/container/alpine/opt/cfx-server/FXServer)
Error loading shared library libstdc++.so.6: No such file or directory (needed by /home/container/alpine/opt/cfx-server/libCoreRT.so)
```

Test image: `quintenqvd/pterodactyl_images:temp_fivem`
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

