### PR TITLE
Make the installer image work for ARM64 and AMD64

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -21,6 +21,7 @@ jobs:
           - ubuntu
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
           buildkitd-flags: --debug
@@ -33,7 +34,7 @@ jobs:
         with:
           context: ./installers
           file: ./installers/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/parkervcp/installers:${{ matrix.tag }}

--- a/installers/debian/Dockerfile
+++ b/installers/debian/Dockerfile
@@ -29,7 +29,12 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 ENV         DEBIAN_FRONTEND=noninteractive
 
-RUN         dpkg --add-architecture i386 \
-				&& apt update \
-				&& apt upgrade -y \
-				&& apt -y --no-install-recommends install ca-certificates curl lib32gcc-s1 libsdl2-2.0-0:i386 git unzip zip tar jq wget
+RUN      apt update && apt upgrade -y \
+         && apt -y --no-install-recommends install ca-certificates curl git unzip zip tar jq wget
+
+# Only install the needed steamcmd packages on the AMD64 build
+RUN         if [ "$(uname -m)" = "x86_64" ]; then \
+                dpkg --add-architecture i386 && \
+                apt update && \
+                apt -y install lib32gcc-s1 libsdl2-2.0-0:i386; \
+            fi


### PR DESCRIPTION
## Description

- add some special bash magic to the Debian installer image so it can build for arm64 and amd64

Tested:
Dockerfile: https://github.com/QuintenQVD0/yolks/blob/master/temp/installer_debian/Dockerfile
GitHub build: https://github.com/QuintenQVD0/yolks/actions/runs/5701591366/job/15452450909

AMD64
![afbeelding](https://github.com/parkervcp/yolks/assets/67589015/44f1844e-f1cf-43f6-ab34-7284247fc65b)
ARM64
![afbeelding](https://github.com/parkervcp/yolks/assets/67589015/720d6539-d7b5-4add-9545-a78a9ef61540)

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->
