### PR TITLE
Fix entrypoint.sh permissions in dockerfiles

### DIFF
--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -14,4 +14,5 @@ ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 COPY        ./../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
 CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -13,4 +13,5 @@ WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
+RUN         chmod +x /entrypoint.sh
 CMD         ["/bin/bash", "/entrypoint.sh"]

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -14,4 +14,5 @@ ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 COPY        ./../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
 CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -13,4 +13,5 @@ WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
+RUN         chmod +x /entrypoint.sh
 CMD         ["/bin/bash", "/entrypoint.sh"]

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -14,4 +14,5 @@ ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 COPY        ./../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
 CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -14,4 +14,5 @@ ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 COPY        ./../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
 CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -14,4 +14,5 @@ ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 COPY        ./../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
 CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -13,4 +13,5 @@ WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
+RUN         chmod +x /entrypoint.sh
 CMD         ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
## Description

Fix #173 

When starting Java containers (Java 17 tested) on the latest build (released <1 hour ago) the following error occurs indicating a permissions issue with the entrypoint file:
```
environment/docker: failed to start container: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/entrypoint.sh": permission denied: unknown
```

This PR resolves the permissions issue by executing a chmod command in each Dockerfile.
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
