### PR TITLE
mono: make steamcmd work and build for arm64

### DIFF
--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           context: ./mono
           file: ./mono/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/parkervcp/yolks:mono_${{ matrix.tag }}

--- a/mono/entrypoint.sh
+++ b/mono/entrypoint.sh
@@ -1,13 +1,52 @@
 #!/bin/bash
-cd /home/container
+# Wait for the container to fully initialize
+sleep 1
 
-# Make internal Docker IP address available to processes.
+# Default the TZ environment variable to UTC.
+TZ=${TZ:-UTC}
+export TZ
+
+# Set environment variable that holds the Internal Docker IP
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
 
+# Switch to the container's working directory
+cd /home/container || exit 1
+
+if [ ! -z "${SRCDS_APPID}" ]; then
+    ## just in case someone removed the defaults.
+    if [ "${STEAM_USER}" == "" ]; then
+        echo -e "steam user is not set.\n"
+        echo -e "Using anonymous user.\n"
+        STEAM_USER=anonymous
+        STEAM_PASS=""
+        STEAM_AUTH=""
+    else
+        echo -e "user set to ${STEAM_USER}"
+    fi
+
+    ## if auto_update is not set or to 1 update
+    if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then 
+        # Update Source Server
+        if [ ! -z ${SRCDS_APPID} ]; then
+            if [ "${STEAM_USER}" == "anonymous" ]; then
+                ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
+            else
+                numactl --physcpubind=+0 ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
+            fi
+        else
+            echo -e "No appid set. Starting Server"
+        fi
+
+    else
+        echo -e "Not updating game server as auto update was set to 0. Starting Server"
+    fi
+fi
+
+
 # Replace Startup Variables
-MODIFIED_STARTUP="eval $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')"
-echo ":/home/container$ ${MODIFIED_STARTUP}"
+MODIFIED_STARTUP=$(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+echo -e ":/home/container$ ${MODIFIED_STARTUP}"
 
 # Run the Server
-${MODIFIED_STARTUP}
+eval ${MODIFIED_STARTUP}

--- a/mono/latest/Dockerfile
+++ b/mono/latest/Dockerfile
@@ -1,14 +1,22 @@
-FROM        ghcr.io/parkervcp/yolks:debian
+FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="support@goover.de"
 
 RUN         apt update \
             && apt -y upgrade
-RUN         apt install -y fontconfig dirmngr
+RUN         apt install -y fontconfig dirmngr numactl
 RUN         apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN         sh -c 'echo "deb https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list'
 RUN         apt update
-RUN         apt install -y mono-complete lib32gcc-s1
+RUN         apt install -y mono-complete
+
+# Only install the needed steamcmd packages on the AMD64 build
+RUN         if [ "$(uname -m)" = "x86_64" ]; then \
+                dpkg --add-architecture i386 && \
+                apt update && \
+                apt -y install lib32gcc-s1 libsdl2-2.0-0:i386; \
+            fi
+
 
 USER        container
 ENV         USER=container HOME=/home/container


### PR DESCRIPTION
## Description

- make the mono image build for arm64
- add the steamcmd update logic to the entrypoint but with 1 extra check so non steam users do not see all those echo

builds take now 11m10s as it has to ofc make 2 images and build mono 2 times ( this is how the mono install works, it always has) 

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

