### PR TITLE
Update go to build 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,14 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         tag:
-          - 1.14
-          - 1.15
-          - 1.16
-          - 1.17
-          - 1.18
-          - 1.19
-          - 1.20
-          - 1.21
+          - '1.14'
+          - '1.15'
+          - '1.16'
+          - '1.17'
+          - '1.18'
+          - '1.19'
+          - '1.20'
+          - '1.21'
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
## Description

Because golang 1.20 and 1.21 where added but  github auto strips the last char away if it is a 0 so the 1.20 did not build as it is looking for 1.2

See: https://github.com/parkervcp/yolks/actions/runs/6554656375/job/17801979148

This PR add ' ' arround all versions and then normaly github will not ignore the last 0

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

