### PR TITLE
Add tini to nodejs 17 image

### DIFF
--- a/nodejs/17/Dockerfile
+++ b/nodejs/17/Dockerfile
@@ -3,7 +3,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH node:17-bullseye-slim
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 RUN         apt update \
-            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool iputils-ping libnss3 libnss3 \
+            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool iputils-ping libnss3 libnss3 tini \
             && useradd -m -d /home/container container
 
 RUN         npm install npm@8.11.0 typescript ts-node @types/node --location=global


### PR DESCRIPTION
adds tini to the nodejs 17 image

## Description
nodejs 17 image was missing the tini binary.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

