### PR TITLE
Add dotnet_8

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ is tagged correctly.
   * `ghcr.io/parkervcp/yolks:dotnet_6`
 * [`dotnet7.0`](/dotnet/7)
   * `ghcr.io/parkervcp/yolks:dotnet_7`
+* [`dotnet8.0`](/dotnet/8)
+  * `ghcr.io/parkervcp/yolks:dotnet_8`
 
 ### [Elixir](/elixir)
 


### PR DESCRIPTION
Add dotnet_8 to README

Forgot to modify this file in my previous PR. 

I'm using at the moment the dotnet_8 image and everything it's fine, maybe the readme will help others know that this is an option. 