### PR TITLE
TeaSpeak replaced youtube-dl with ytdlp

### DIFF
--- a/voice/teaspeak/Dockerfile
+++ b/voice/teaspeak/Dockerfile
@@ -37,7 +37,7 @@ RUN       apt update \
 RUN   apt install -y ffmpeg curl python3 iproute2 libjemalloc2 tini
 
 # Install latest youtube-dl
-RUN   curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
+RUN   curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/youtube-dl
 RUN   chmod a+rx /usr/local/bin/youtube-dl
 
 RUN   update-alternatives --install  /usr/bin/python python /usr/bin/python3 1000


### PR DESCRIPTION
## Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

I have replaced youtube-dl with ytdlp because youtube-dl can no longer be developed further. Because it was taken down.
youtube-dl takedown report: 
https://yt-dl.org/
https://openjur.de/u/2466945.html

### All Submissions:

* [X] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [X] Have you created a new branch for your changes and PR from that branch and not from your master branch?