### PR TITLE
Add Java 21 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ is tagged correctly.
   * `ghcr.io/parkervcp/yolks:java_17`
 * [`java19`](/java/19)
   * `ghcr.io/parkervcp/yolks:java_19`
+* [`java21`](/java/21)
+  * `ghcr.io/parkervcp/yolks:java_21`
 
 ### [MariaDB](/mariadb)
 


### PR DESCRIPTION
## Description

Java 21 was added to the repository, but the author of the PR missed to add it in the readme, this pr just adds it 

Original PR:
https://github.com/parkervcp/yolks/pull/193

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [x] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
2. [x] Have you updated the README list to contain your new image?
