### PR TITLE
Add NodeJS 21

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,6 +23,7 @@ jobs:
           - 18
           - 19
           - 20
+          - 21
     steps:
       - uses: actions/checkout@v4
       # Setup QEMU for ARM64 Build

--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ is tagged correctly.
   * `ghcr.io/parkervcp/yolks:nodejs_19`
 * [`node20`](/nodejs/20)
   * `ghcr.io/parkervcp/yolks:nodejs_20`
-
+* [`node21`](/nodejs/21)
+  * `ghcr.io/parkervcp/yolks:nodejs_21`
 
 ### [PostgreSQL](/postgres)
 

--- a/nodejs/21/Dockerfile
+++ b/nodejs/21/Dockerfile
@@ -1,0 +1,20 @@
+FROM        --platform=$TARGETOS/$TARGETARCH node:21-bullseye-slim
+
+LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+
+RUN         apt update \
+            && apt -y install ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool iputils-ping libnss3 tini \
+            && useradd -m -d /home/container container
+
+RUN         npm install npm@latest typescript ts-node @types/node --location=global
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+STOPSIGNAL SIGINT
+
+COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+CMD         ["/entrypoint.sh"]


### PR DESCRIPTION
## Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

This PR adds NodeJS 21. I checked and saw no other pull requests regarding node 21, decided to create one using the 21-bullseye-slim tag like the dockerfile for node20 was using, just 21-bullseye-slim not 20-bullseye-slim

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [x] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
2. [x] Have you updated the README list to contain your new image?
