### PR TITLE
Add python3-pip and pythons requests lib for ytdl wrapper to sinusbot image

### DIFF
--- a/bot/sinusbot/Dockerfile
+++ b/bot/sinusbot/Dockerfile
@@ -8,11 +8,12 @@ ENV         DEBIAN_FRONTEND noninteractive
 # Install Dependencies
 RUN         apt update \
             && apt upgrade -y \
-            && apt install -y ca-certificates less locales pulseaudio python python3 sudo x11vnc x11-xkb-utils xvfb iproute2 ffmpeg curl liblcms2-2 libatomic1 libxcb-xinerama0 fontconfig \
-			libasound2 libegl1-mesa libglib2.0-0 libnss3 libpci3 libpulse0 libxcursor1 libxslt1.1 libx11-xcb1 libxkbcommon0 bzip2 libxss1 libxcomposite1 libevent-2.1-7 libxcb-icccm4 \
-   			libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0 tini \
+            && apt install -y ca-certificates less locales pulseaudio python python3 python3-pip sudo x11vnc x11-xkb-utils xvfb iproute2 ffmpeg curl liblcms2-2 libatomic1 libxcb-xinerama0 \
+			fontconfig libasound2 libegl1-mesa libglib2.0-0 libnss3 libpci3 libpulse0 libxcursor1 libxslt1.1 libx11-xcb1 libxkbcommon0 bzip2 libxss1 libxcomposite1 libevent-2.1-7 \
+			libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0 tini \
+            && python3 -m pip install requests \
             && useradd -m -d /home/container container
-
+#RUN         python3 -m pip install requests
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
## Description

Using sinusbot with ytdl causes errors like `error getting samples: could not decode frame: -541478725`. After discussion on Sinusbot discord guild they suggest to use @elderlabs's yt-dl_wrapper.pl script. I don't attach script, it should be done by egg install script like ytdl lib. 

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?