### PR TITLE
steamcmd: dotnet 8

### DIFF
--- a/steamcmd/dotnet/Dockerfile
+++ b/steamcmd/dotnet/Dockerfile
@@ -18,7 +18,7 @@ RUN     apt update -y \
           && dpkg -i packages-microsoft-prod.deb \
           && rm packages-microsoft-prod.deb \
           && apt update -y \
-          && apt install -y aspnetcore-runtime-7.0 dotnet-sdk-7.0 libgdiplus
+          && apt install -y aspnetcore-runtime-7.0 dotnet-sdk-7.0 libgdiplus aspnetcore-runtime-8.0 dotnet-sdk-8.0
 
 ## install rcon
 RUN         cd /tmp/ \


### PR DESCRIPTION
## Description

- add dotnet 8 to the dotnet steamcmd image
- dotnet 7 support will end on May 14, 2024, so I added 8 for now but kept 7 for compatibility 

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

