### PR TITLE
fix the builds

### DIFF
--- a/bot/sinusbot/Dockerfile
+++ b/bot/sinusbot/Dockerfile
@@ -10,8 +10,8 @@ RUN         apt update \
             && apt upgrade -y \
             && apt install -y ca-certificates less locales pulseaudio python3 python3-pip sudo x11vnc x11-xkb-utils xvfb iproute2 ffmpeg curl liblcms2-2 libatomic1 libxcb-xinerama0 \
 			fontconfig libasound2 libegl1-mesa libglib2.0-0 libnss3 libpci3 libpulse0 libxcursor1 libxslt1.1 libx11-xcb1 libxkbcommon0 bzip2 libxss1 libxcomposite1 libevent-2.1-7 \
-			libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0 tini \
-            && python3 -m pip install requests \
+			libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0 tini pipx \
+            && pipx install requests \
             && useradd -m -d /home/container container
 #RUN         python3 -m pip install requests
 

--- a/bot/sinusbot/Dockerfile
+++ b/bot/sinusbot/Dockerfile
@@ -10,8 +10,7 @@ RUN         apt update \
             && apt upgrade -y \
             && apt install -y ca-certificates less locales pulseaudio python3 python3-pip sudo x11vnc x11-xkb-utils xvfb iproute2 ffmpeg curl liblcms2-2 libatomic1 libxcb-xinerama0 \
 			fontconfig libasound2 libegl1-mesa libglib2.0-0 libnss3 libpci3 libpulse0 libxcursor1 libxslt1.1 libx11-xcb1 libxkbcommon0 bzip2 libxss1 libxcomposite1 libevent-2.1-7 \
-			libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0 tini pipx \
-            && pipx install requests \
+			libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0 tini \
             && useradd -m -d /home/container container
 #RUN         python3 -m pip install requests
 

--- a/bot/sinusbot/entrypoint.sh
+++ b/bot/sinusbot/entrypoint.sh
@@ -5,6 +5,9 @@ cd /home/container
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
 
+# PipX PATH fix
+export PATH=$PATH:/root/.local/bin
+
 # Replace Startup Variables
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"

--- a/bot/sinusbot/entrypoint.sh
+++ b/bot/sinusbot/entrypoint.sh
@@ -5,8 +5,6 @@ cd /home/container
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
 
-# PipX PATH fix
-export PATH=$PATH:/root/.local/bin
 
 # Replace Startup Variables
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`

--- a/games/altv/Dockerfile
+++ b/games/altv/Dockerfile
@@ -15,15 +15,10 @@ RUN     apt update -y \
         libfontconfig1 libicu72 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata libgdiplus\ 
 		python3 dnsutils build-essential coreutils jq pcregrep tini
 
-RUN     wget https://dot.net/v1/dotnet-install.sh \
-        && D_V_5="$(curl -sSL https://dotnet.microsoft.com/en-us/download/dotnet/5.0 | grep -i  '<h3 id="sdk-5.*">SDK 5.*.*</h3>'  | head -1 | awk -F\" '{print $3}' | awk '{print $2;}' | sed 's/<\/h3>//g')" \
-        && D_V_6="$(curl -sSL https://dotnet.microsoft.com/en-us/download/dotnet/6.0 | grep -i  '<h3 id="sdk-5.*">SDK 6.*.*</h3>'  | head -1 | awk -F\" '{print $3}' | awk '{print $2;}' | sed 's/<\/h3>//g')" \
-        && D_V_7="$(curl -sSL https://dotnet.microsoft.com/en-us/download/dotnet/7.0 | grep -i  '<h3 id="sdk-5.*">SDK 7.*.*</h3>'  | head -1 | awk -F\" '{print $3}' | awk '{print $2;}' | sed 's/<\/h3>//g')" \
-        && chmod +x dotnet-install.sh \
-	&& ./dotnet-install.sh -i /usr/share -v $D_V_5 \
-        && ./dotnet-install.sh -i /usr/share -v $D_V_6 \
-        && ./dotnet-install.sh -i /usr/share -v $D_V_7 \
-        && ln -s /usr/share/dotnet /usr/bin/dotnet
+RUN     wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+        && dpkg -i packages-microsoft-prod.deb \
+        && apt update -y \
+        && apt install -y dotnet-sdk-6.0 dotnet-sdk-7.0 libgdiplus
 
 RUN     update-locale lang=en_US.UTF-8 \
         && dpkg-reconfigure --frontend noninteractive locales

--- a/games/altv/Dockerfile
+++ b/games/altv/Dockerfile
@@ -18,7 +18,7 @@ RUN     apt update -y \
 RUN     wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
         && dpkg -i packages-microsoft-prod.deb \
         && apt update -y \
-        && apt install -y dotnet-sdk-5.0 dotnet-sdk-6.0 dotnet-sdk-7.0 libgdiplus
+        && apt install -y dotnet-sdk-6.0 dotnet-sdk-7.0 libgdiplus
 
 RUN     update-locale lang=en_US.UTF-8 \
         && dpkg-reconfigure --frontend noninteractive locales

--- a/games/altv/Dockerfile
+++ b/games/altv/Dockerfile
@@ -12,13 +12,18 @@ RUN     useradd -m -d /home/container -s /bin/bash container
 RUN     apt update -y \
         && apt upgrade -y \
         && apt install -y g++ gcc libgcc-s1 lib32gcc-s1 gdb libstdc++6 libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat-traditional telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
-        libfontconfig1 libicu72 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata \
+        libfontconfig1 libicu72 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata libgdiplus\ 
 		python3 dnsutils build-essential coreutils jq pcregrep tini
 
-RUN     wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-        && dpkg -i packages-microsoft-prod.deb \
-        && apt update -y \
-        && apt install -y dotnet-sdk-6.0 dotnet-sdk-7.0 libgdiplus
+RUN     wget https://dot.net/v1/dotnet-install.sh \
+        && D_V_5="$(curl -sSL https://dotnet.microsoft.com/en-us/download/dotnet/5.0 | grep -i  '<h3 id="sdk-5.*">SDK 5.*.*</h3>'  | head -1 | awk -F\" '{print $3}' | awk '{print $2;}' | sed 's/<\/h3>//g')" \
+        && D_V_6="$(curl -sSL https://dotnet.microsoft.com/en-us/download/dotnet/6.0 | grep -i  '<h3 id="sdk-5.*">SDK 6.*.*</h3>'  | head -1 | awk -F\" '{print $3}' | awk '{print $2;}' | sed 's/<\/h3>//g')" \
+        && D_V_7="$(curl -sSL https://dotnet.microsoft.com/en-us/download/dotnet/7.0 | grep -i  '<h3 id="sdk-5.*">SDK 7.*.*</h3>'  | head -1 | awk -F\" '{print $3}' | awk '{print $2;}' | sed 's/<\/h3>//g')" \
+        && chmod +x dotnet-install.sh \
+	&& ./dotnet-install.sh -i /usr/share -v $D_V_5 \
+        && ./dotnet-install.sh -i /usr/share -v $D_V_6 \
+        && ./dotnet-install.sh -i /usr/share -v $D_V_7 \
+        && ln -s /usr/share/dotnet /usr/bin/dotnet
 
 RUN     update-locale lang=en_US.UTF-8 \
         && dpkg-reconfigure --frontend noninteractive locales

--- a/games/altv/Dockerfile
+++ b/games/altv/Dockerfile
@@ -11,7 +11,7 @@ RUN     useradd -m -d /home/container -s /bin/bash container
 
 RUN     apt update -y \
         && apt upgrade -y \
-        && apt install -y g++ gcc libgcc-s1 lib32gcc-s1 gdb libstdc++6 libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+        && apt install -y g++ gcc libgcc-s1 lib32gcc-s1 gdb libstdc++6 libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat-traditional telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
         libfontconfig1 libicu72 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata \
 		python3 dnsutils build-essential coreutils jq pcregrep tini
 

--- a/games/altv/entrypoint.sh
+++ b/games/altv/entrypoint.sh
@@ -5,8 +5,6 @@ cd /home/container
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
 
-export DOTNET_ROOT=/usr/share/
-
 # Replace Startup Variables
 MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 echo -e ":/home/container$ ${MODIFIED_STARTUP}"

--- a/games/altv/entrypoint.sh
+++ b/games/altv/entrypoint.sh
@@ -5,6 +5,8 @@ cd /home/container
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
 
+export DOTNET_ROOT=/usr/share/
+
 # Replace Startup Variables
 MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 echo -e ":/home/container$ ${MODIFIED_STARTUP}"

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -41,6 +41,13 @@ RUN         cd /tmp/ \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
 
+        # Temp fix for things that still need libssl1.1
+RUN     if [ "$(uname -m)" = "x86_64" ]; then \
+            wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+            dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+            rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
+        fi
+        
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -32,7 +32,7 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
             && apt update \
             && apt upgrade -y \
-            && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc-11-dev libgcc-12-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata numactl tini \
+            && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc-11-dev libgcc-12-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl tini \
             && useradd -m -d /home/container container
 
 ## install rcon

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -32,7 +32,7 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
             && apt update \
             && apt upgrade -y \
-            && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc-11-dev libgcc-12-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl tini \
+            && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc-11-dev libgcc-12-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl wget tini \
             && useradd -m -d /home/container container
 
 ## install rcon

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -27,7 +27,7 @@ RUN         if [ "$(uname -m)" = "x86_64" ]; then \
                 wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2.1_amd64.deb && \
                 wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
                 dpkg -i libicu66_66.1-2ubuntu2.1_amd64.deb && \
-                dkpk -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
                 rm libicu66_66.1-2ubuntu2.1_amd64.deb libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
             fi
 # ARM64

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -19,8 +19,15 @@ RUN          apt update \
 
 ## Install dependencies
 RUN          apt install -y gcc g++ libgcc-12-dev libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat-traditional telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
-             libfontconfig1 libicu72 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev-compat libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
+             libfontconfig1 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev-compat libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
              liblua5.3-0 libz3-dev libzadc4 rapidjson-dev tzdata libevent-dev libzip4 libprotobuf32 libfluidsynth3 procps libstdc++6 tini
+
+# Temp fix for libicu66.1 for RAGE-MP
+RUN         if [ "$(uname -m)" = "x86_64" ]; then \
+                wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2.1_amd64.deb && \
+                dpkg -i libicu66_66.1-2ubuntu2.1_amd64.deb && \
+                rm libicu66_66.1-2ubuntu2.1_amd64.deb; \
+            fi
 
 ## Configure locale
 RUN          update-locale lang=en_US.UTF-8 \

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -29,7 +29,9 @@ RUN         if [ "$(uname -m)" = "x86_64" ]; then \
                 dpkg -i libicu66_66.1-2ubuntu2.1_amd64.deb && \
                 dkpk -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
                 rm libicu66_66.1-2ubuntu2.1_amd64.deb libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
-            else \
+            fi
+# ARM64
+RUN         if [ ! "$(uname -m)" = "x86_64" ]; then \
                 wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb && \
                 dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb && \
                 rm libssl1.1_1.1.1f-1ubuntu2_arm64.deb; \

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -22,11 +22,17 @@ RUN          apt install -y gcc g++ libgcc-12-dev libc++-dev gdb libc6 git wget 
              libfontconfig1 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev-compat libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
              liblua5.3-0 libz3-dev libzadc4 rapidjson-dev tzdata libevent-dev libzip4 libprotobuf32 libfluidsynth3 procps libstdc++6 tini
 
-# Temp fix for libicu66.1 for RAGE-MP
+# Temp fix for libicu66.1 for RAGE-MP and libssl1.1 for fivem and many more
 RUN         if [ "$(uname -m)" = "x86_64" ]; then \
                 wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2.1_amd64.deb && \
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
                 dpkg -i libicu66_66.1-2ubuntu2.1_amd64.deb && \
-                rm libicu66_66.1-2ubuntu2.1_amd64.deb; \
+                dkpk -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+                rm libicu66_66.1-2ubuntu2.1_amd64.deb libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
+            else \
+                wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb && \
+                dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb && \
+                rm libssl1.1_1.1.1f-1ubuntu2_arm64.deb; \
             fi
 
 ## Configure locale

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -27,7 +27,7 @@ RUN         if [ "$(uname -m)" = "x86_64" ]; then \
                 wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2.1_amd64.deb && \
                 wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
                 dpkg -i libicu66_66.1-2ubuntu2.1_amd64.deb && \
-                dkpk -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+                dkpk -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
                 rm libicu66_66.1-2ubuntu2.1_amd64.deb libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
             fi
 # ARM64

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -18,7 +18,7 @@ RUN          apt update \
              && apt upgrade -y
 
 ## Install dependencies
-RUN          apt install -y gcc g++ libgcc-12-dev libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+RUN          apt install -y gcc g++ libgcc-12-dev libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat-traditional telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
              libfontconfig1 libicu72 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadb-dev-compat libduktape207 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates \
              liblua5.3-0 libz3-dev libzadc4 rapidjson-dev tzdata libevent-dev libzip4 libprotobuf32 libfluidsynth3 procps libstdc++6 tini
 

--- a/steamcmd/debian/Dockerfile
+++ b/steamcmd/debian/Dockerfile
@@ -10,7 +10,7 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
             && apt-get update \
             && apt-get upgrade -y \
-            && apt-get install -y tar curl gcc g++ lib32gcc-s1 libgcc-12-dev libgcc-11-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 libsdl2-2.0-0 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata numactl xvfb tini \
+            && apt-get install -y tar curl gcc g++ lib32gcc-s1 libgcc-12-dev libgcc-11-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 libsdl2-2.0-0 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl xvfb tini \
             && useradd -m -d /home/container container
 
 ## install rcon

--- a/steamcmd/debian/Dockerfile
+++ b/steamcmd/debian/Dockerfile
@@ -19,6 +19,13 @@ RUN         cd /tmp/ \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
 
+            # Temp fix for things that still need libssl1.1
+RUN         if [ "$(uname -m)" = "x86_64" ]; then \
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
+            fi
+
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container

--- a/steamcmd/debian/Dockerfile
+++ b/steamcmd/debian/Dockerfile
@@ -10,7 +10,7 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
             && apt-get update \
             && apt-get upgrade -y \
-            && apt-get install -y tar curl gcc g++ lib32gcc-s1 libgcc-12-dev libgcc-11-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 libsdl2-2.0-0 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl xvfb tini \
+            && apt-get install -y tar curl gcc g++ lib32gcc-s1 libgcc-12-dev libgcc-11-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 libsdl2-2.0-0 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl xvfb wget tini \
             && useradd -m -d /home/container container
 
 ## install rcon

--- a/steamcmd/dotnet/Dockerfile
+++ b/steamcmd/dotnet/Dockerfile
@@ -7,7 +7,7 @@ ENV     DEBIAN_FRONTEND noninteractive
 RUN     dpkg --add-architecture i386 \
           && apt update \
           && apt upgrade -y \
-          && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc1 libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata \
+          && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc1 libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata \
           && apt install -y libstdc++6 libstdc++6:i386 libc6-amd64 libc6:i386 psmisc libgdiplus libcurl4 libfontconfig1 libpangocairo-1.0-0 libnss3 libgconf-2-4 libxi6 libxcursor1 libxss1 libxcomposite1 libasound2 libxdamage1 libxtst6 libatk1.0-0 libxrandr2 libcurl4 xvfb mesa-utils git \
           && apt install -y python3 python3-dev python3-pip apt-transport-https wget iproute2 sqlite3 xvfb tini \
           && useradd -d /home/container -m container

--- a/steamcmd/entrypoint.sh
+++ b/steamcmd/entrypoint.sh
@@ -39,6 +39,8 @@ if [ -f "/usr/local/bin/proton" ]; then
 	    mkdir -p /home/container/.steam/steam/steamapps/compatdata/${SRCDS_APPID}
         export STEAM_COMPAT_CLIENT_INSTALL_PATH="/home/container/.steam/steam"
         export STEAM_COMPAT_DATA_PATH="/home/container/.steam/steam/steamapps/compatdata/${SRCDS_APPID}"
+        # Fix for pipx with protontricks
+        export PATH=$PATH:/root/.local/bin
     else
         echo -e "----------------------------------------------------------------------------------"
         echo -e "WARNING!!! Proton needs variable SRCDS_APPID, else it will not work. Please add it"

--- a/steamcmd/proton/Dockerfile
+++ b/steamcmd/proton/Dockerfile
@@ -9,7 +9,7 @@ LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 RUN         dpkg --add-architecture i386
 RUN         apt update
 RUN         apt install -y --no-install-recommends wget iproute2 gnupg2 software-properties-common libntlm0 winbind xvfb xauth libncurses5-dev:i386 libncurses6 dbus libgdiplus lib32gcc-s1
-RUN         apt install -y alsa-tools libpulse0 pulseaudio libpulse-dev libasound2 libao-common gnutls-bin gnupg locales numactl cabextract curl python3 python3-pip python3-setuptools tini file
+RUN         apt install -y alsa-tools libpulse0 pulseaudio libpulse-dev libasound2 libao-common gnutls-bin gnupg locales numactl cabextract curl python3 python3-pip python3-setuptools tini file pipx
 RUN         useradd -d /home/container -m container
 
 # Download Proton GE
@@ -24,7 +24,7 @@ RUN         rm /var/lib/dbus/machine-id
 RUN         dbus-uuidgen --ensure
 
 #Setup Protontricks
-RUN         python3 -m pip install protontricks
+RUN        pipx install protontricks
 
 # Set up Winetricks
 RUN	        wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \

--- a/steamcmd/proton_8/Dockerfile
+++ b/steamcmd/proton_8/Dockerfile
@@ -9,7 +9,7 @@ LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 RUN         dpkg --add-architecture i386
 RUN         apt update
 RUN         apt install -y --no-install-recommends wget iproute2 gnupg2 software-properties-common libntlm0 winbind xvfb xauth libncurses5-dev:i386 libncurses6 dbus libgdiplus lib32gcc-s1
-RUN         apt install -y alsa-tools libpulse0 pulseaudio libpulse-dev libasound2 libao-common gnutls-bin gnupg locales numactl cabextract curl python3 python3-pip python3-setuptools tini file
+RUN         apt install -y alsa-tools libpulse0 pulseaudio libpulse-dev libasound2 libao-common gnutls-bin gnupg locales numactl cabextract curl python3 python3-pip python3-setuptools tini file pipx
 RUN         useradd -d /home/container -m container
 
 # Download Proton GE
@@ -24,7 +24,7 @@ RUN         rm /var/lib/dbus/machine-id
 RUN         dbus-uuidgen --ensure
 
 #Setup Protontricks
-RUN         python3 -m pip install protontricks
+RUN         pipx install protontricks
 
 # Set up Winetricks
 RUN	        wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \


### PR DESCRIPTION
## Description

- Should fix all currently failing builds because netcat is a valid package but apt can not decide on use  netcat-traditional or  netcat-openbsd
- add a hacky way for libssl1.1 to still be their in the debian image
- remove dotnet 5 from altv
- revert to libicu66 on the debian image because it broke rage-mp

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->


