### PR TITLE
[General] Remove `numactl` & Dockerfile Cleanup

### DIFF
--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -32,29 +32,65 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
             && apt update \
             && apt upgrade -y \
-            && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc-11-dev libgcc-12-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl wget tini \
-            && useradd -m -d /home/container container
+            && apt install -y \
+                curl \
+                g++ \
+                gcc \
+                gdb \
+                iproute2 \
+                locales \
+                net-tools \
+                netcat-traditional \
+                tar \
+                telnet \
+                tini \
+                tzdata \
+                wget \
+                lib32gcc-s1 \
+                lib32stdc++6 \
+                lib32tinfo6 \
+                lib32z1 \
+                libcurl3-gnutls:i386 \
+                libcurl4-gnutls-dev:i386 \
+                libcurl4:i386 \
+                libfontconfig1 \
+                libgcc-11-dev \
+                libgcc-12-dev \
+                libncurses5:i386 \
+                libsdl1.2debian \
+                libsdl2-2.0-0:i386 \
+                libssl-dev:i386 \
+                libtinfo6:i386 \
 
-## install rcon
+# Install rcon
 RUN         cd /tmp/ \
             && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
 
-        # Temp fix for things that still need libssl1.1
-RUN     if [ "$(uname -m)" = "x86_64" ]; then \
-            wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
-            dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
-            rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
-        fi
+# Temp fix for things that still need libssl1.1
+RUN         if [ "$(uname -m)" = "x86_64" ]; then \
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
+            fi
         
+# Set the locale
+RUN         sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+            locale-gen
+ENV         LANG=en_US.UTF-8
+ENV         LANGUAGE=en_US:en
+ENV         LC_ALL=en_US.UTF-8
+
+# Setup user and working directory
+RUN         useradd -m -d /home/container -s /bin/bash container
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
-STOPSIGNAL SIGINT
+STOPSIGNAL  SIGINT
 
 COPY        --chown=container:container ./entrypoint.sh /entrypoint.sh
 RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+ENTRYPOINT  ["/usr/bin/tini", "-g", "--"]
 CMD         ["/entrypoint.sh"]

--- a/games/source/entrypoint.sh
+++ b/games/source/entrypoint.sh
@@ -52,11 +52,7 @@ fi
 if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then 
     # Update Source Server
     if [ ! -z ${SRCDS_APPID} ]; then
-	    if [ "${STEAM_USER}" == "anonymous" ]; then
-            ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
-	    else
-            numactl --physcpubind=+0 ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
-	    fi
+	    ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
     else
         echo -e "No appid set. Starting Server"
     fi

--- a/mono/entrypoint.sh
+++ b/mono/entrypoint.sh
@@ -29,11 +29,7 @@ if [ ! -z "${SRCDS_APPID}" ]; then
     if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then 
         # Update Source Server
         if [ ! -z ${SRCDS_APPID} ]; then
-            if [ "${STEAM_USER}" == "anonymous" ]; then
-                ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
-            else
-                numactl --physcpubind=+0 ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
-            fi
+            ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
         else
             echo -e "No appid set. Starting Server"
         fi

--- a/mono/latest/Dockerfile
+++ b/mono/latest/Dockerfile
@@ -4,7 +4,7 @@ LABEL       author="Torsten Widmann" maintainer="support@goover.de"
 
 RUN         apt update \
             && apt -y upgrade
-RUN         apt install -y fontconfig dirmngr numactl
+RUN         apt install -y fontconfig dirmngr
 RUN         apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN         sh -c 'echo "deb https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list'
 RUN         apt update

--- a/steamcmd/debian/Dockerfile
+++ b/steamcmd/debian/Dockerfile
@@ -8,49 +8,48 @@ LABEL       org.opencontainers.image.licenses=MIT
 ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         dpkg --add-architecture i386 \
-            && apt-get update \
-            && apt-get upgrade -y \
-            && apt-get install -y \
-				curl \
-				g++ \
-				gcc \
-				gdb \
-				iproute2 \
-				locales \
-				net-tools \
-				netcat-traditional \
-				numactl \
-				tar \
-				telnet \
-				tini \
-				tzdata \
-				wget \
-				xvfb \
-				lib32gcc-s1 \
-				lib32stdc++6 \
-				lib32tinfo6 \
-				lib32z1 \
-				libcurl3-gnutls:i386 \
-				libcurl4-gnutls-dev:i386 \
-				libcurl4:i386 \
-				libfontconfig1 \
-				libgcc-11-dev \
-				libgcc-12-dev \
-				libncurses5:i386 \
-				libsdl1.2debian \
-				libsdl2-2.0-0 \
-				libsdl2-2.0-0:i386 \
-				libssl-dev:i386 \
-				libtinfo6:i386
+            && apt update \
+            && apt upgrade -y \
+            && apt install -y \
+                curl \
+                g++ \
+                gcc \
+                gdb \
+                iproute2 \
+                locales \
+                net-tools \
+                netcat-traditional \
+                tar \
+                telnet \
+                tini \
+                tzdata \
+                wget \
+                xvfb \
+                lib32gcc-s1 \
+                lib32stdc++6 \
+                lib32tinfo6 \
+                lib32z1 \
+                libcurl3-gnutls:i386 \
+                libcurl4-gnutls-dev:i386 \
+                libcurl4:i386 \
+                libfontconfig1 \
+                libgcc-11-dev \
+                libgcc-12-dev \
+                libncurses5:i386 \
+                libsdl1.2debian \
+                libsdl2-2.0-0 \
+                libsdl2-2.0-0:i386 \
+                libssl-dev:i386 \
+                libtinfo6:i386
 
-## install rcon
+# Install rcon
 RUN         cd /tmp/ \
             && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
 
 
-			## Temp fix for things that still need libssl1.1
+# Temp fix for things that still need libssl1.1
 RUN         if [ "$(uname -m)" = "x86_64" ]; then \
                 wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
                 dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
@@ -58,21 +57,21 @@ RUN         if [ "$(uname -m)" = "x86_64" ]; then \
             fi
 
 # Set the locale
-RUN        	sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
-           	locale-gen
-ENV      	LANG=en_US.UTF-8
-ENV       	LANGUAGE=en_US:en
-ENV        	LC_ALL=en_US.UTF-8
+RUN         sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+            locale-gen
+ENV         LANG=en_US.UTF-8
+ENV         LANGUAGE=en_US:en
+ENV         LC_ALL=en_US.UTF-8
 
-## Setup user and working directory
+# Setup user and working directory
 RUN         useradd -m -d /home/container -s /bin/bash container
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
-STOPSIGNAL SIGINT
+STOPSIGNAL  SIGINT
 
 COPY        --chown=container:container ../entrypoint.sh /entrypoint.sh
 RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+ENTRYPOINT  ["/usr/bin/tini", "-g", "--"]
 CMD         ["/entrypoint.sh"]

--- a/steamcmd/proton/Dockerfile
+++ b/steamcmd/proton/Dockerfile
@@ -5,12 +5,41 @@ FROM        debian:bookworm-slim
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-## install required packages
+# Install required packages
 RUN         dpkg --add-architecture i386
 RUN         apt update
-RUN         apt install -y --no-install-recommends wget iproute2 gnupg2 software-properties-common libntlm0 winbind xvfb xauth libncurses5-dev:i386 libncurses6 dbus libgdiplus lib32gcc-s1
-RUN         apt install -y alsa-tools libpulse0 pulseaudio libpulse-dev libasound2 libao-common gnutls-bin gnupg locales numactl cabextract curl python3 python3-pip python3-setuptools tini file pipx
-RUN         useradd -d /home/container -m container
+RUN         apt install -y --no-install-recommends \
+                wget \
+                iproute2 \
+                gnupg2 \
+                software-properties-common \
+                libntlm0 \
+                winbind \
+                xvfb \
+                xauth \
+                libncurses5-dev:i386 \
+                libncurses6 \
+                dbus \
+                libgdiplus \
+                lib32gcc-s1
+RUN         apt install -y \
+                alsa-tools \
+                libpulse0 \
+                pulseaudio \
+                libpulse-dev \
+                libasound2 \
+                libao-common \
+                gnutls-bin \
+                gnupg \
+                locales \
+                cabextract \
+                curl \
+                python3 \
+                python3-pip \
+                python3-setuptools \
+                tini \
+                file \
+                pipx
 
 # Download Proton GE
 RUN         curl -sLOJ "$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | egrep .tar.gz)"
@@ -23,24 +52,26 @@ RUN         dbus-uuidgen --ensure=/etc/machine-id
 RUN         rm /var/lib/dbus/machine-id
 RUN         dbus-uuidgen --ensure
 
-#Setup Protontricks
-RUN        pipx install protontricks
+# Setup Protontricks
+RUN         pipx install protontricks
 
 # Set up Winetricks
 RUN	        wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
             && chmod +x /usr/sbin/winetricks
 
-## install rcon
+# Install rcon
 RUN         cd /tmp/ \
             && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
             
+# Setup user and working directory
+RUN         useradd -m -d /home/container -s /bin/bash container
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
-STOPSIGNAL SIGINT
+STOPSIGNAL  SIGINT
 
 COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
 RUN         chmod +x /entrypoint.sh

--- a/steamcmd/proton_8/Dockerfile
+++ b/steamcmd/proton_8/Dockerfile
@@ -8,9 +8,38 @@ LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 ## install required packages
 RUN         dpkg --add-architecture i386
 RUN         apt update
-RUN         apt install -y --no-install-recommends wget iproute2 gnupg2 software-properties-common libntlm0 winbind xvfb xauth libncurses5-dev:i386 libncurses6 dbus libgdiplus lib32gcc-s1
-RUN         apt install -y alsa-tools libpulse0 pulseaudio libpulse-dev libasound2 libao-common gnutls-bin gnupg locales numactl cabextract curl python3 python3-pip python3-setuptools tini file pipx
-RUN         useradd -d /home/container -m container
+RUN         apt install -y --no-install-recommends \
+                wget \
+                iproute2 \
+                gnupg2 \
+                software-properties-common \
+                libntlm0 \
+                winbind \
+                xvfb \
+                xauth \
+                libncurses5-dev:i386 \
+                libncurses6 \
+                dbus \
+                libgdiplus \
+                lib32gcc-s1
+RUN         apt install -y \
+                alsa-tools \
+                libpulse0 \
+                pulseaudio \
+                libpulse-dev \
+                libasound2 \
+                libao-common \
+                gnutls-bin \
+                gnupg \
+                locales \
+                cabextract \
+                curl \
+                python3 \
+                python3-pip \
+                python3-setuptools \
+                tini \
+                file \
+                pipx
 
 # Download Proton GE
 RUN         curl -sLOJ "$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/tags/GE-Proton8-32 | grep browser_download_url | cut -d\" -f4 | egrep .tar.gz)"
@@ -23,24 +52,26 @@ RUN         dbus-uuidgen --ensure=/etc/machine-id
 RUN         rm /var/lib/dbus/machine-id
 RUN         dbus-uuidgen --ensure
 
-#Setup Protontricks
+# Setup Protontricks
 RUN         pipx install protontricks
 
 # Set up Winetricks
 RUN	        wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
             && chmod +x /usr/sbin/winetricks
 
-## install rcon
+# Install rcon
 RUN         cd /tmp/ \
             && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
             
+# Setup user and working directory
+RUN         useradd -m -d /home/container -s /bin/bash container
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
-STOPSIGNAL SIGINT
+STOPSIGNAL  SIGINT
 
 COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
 RUN         chmod +x /entrypoint.sh

--- a/steamcmd/sniper/Dockerfile
+++ b/steamcmd/sniper/Dockerfile
@@ -6,24 +6,53 @@ FROM         --platform=$TARGETOS/$TARGETARCH registry.gitlab.steamos.cloud/stea
 LABEL       author="Alexander Ballauf" maintainer="admin@ballaual.de"
 LABEL       org.opencontainers.image.description SteamRT3 Platform image for Pterodactyl Source engine servers. 
 
-## install required packages
+# Install required packages
 RUN         dpkg --add-architecture i386 \
-            && apt-get update \
-            && apt-get upgrade -y \
-            && apt-get install -y tar curl gcc g++ lib32gcc-s1 libgcc1 libcurl4-gnutls-dev:i386 libssl1.1:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 libsdl2-2.0-0 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata numactl xvfb tini libc6 \
-            && useradd -m -d /home/container container
+            && apt update \
+            && apt upgrade -y \
+            && apt install -y \
+                tar \
+                curl \
+                gcc \
+                g++ \
+                lib32gcc-s1 \
+                libgcc1 \
+                libcurl4-gnutls-dev:i386 \
+                libssl1.1:i386 \
+                libcurl4:i386 \
+                lib32tinfo6 \
+                libtinfo6:i386 \
+                lib32z1 \
+                lib32stdc++6 \
+                libncurses5:i386 \
+                libcurl3-gnutls:i386 \
+                libsdl2-2.0-0:i386 \
+                libsdl2-2.0-0 \
+                iproute2 \
+                gdb \
+                libsdl1.2debian \
+                libfontconfig1 \
+                telnet \
+                net-tools \
+                netcat \
+                tzdata \
+                xvfb \
+                tini \
+                libc6
 
-## install rcon
+# Install rcon
 RUN         cd /tmp/ \
             && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
             
+# Setup user and working directory
+RUN         useradd -m -d /home/container -s /bin/bash container
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
-STOPSIGNAL SIGINT
+STOPSIGNAL  SIGINT
 
 COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
 RUN         chmod +x /entrypoint.sh

--- a/wine/10/Dockerfile
+++ b/wine/10/Dockerfile
@@ -6,11 +6,24 @@ FROM            ghcr.io/parkervcp/yolks:debian
 LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL           org.opencontainers.image.licenses=MIT
 
-## install required packages
+# Install required packages
 RUN             dpkg --add-architecture i386 \
                 && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata software-properties-common libntlm0 winbind xvfb xauth python3 libncurses5:i386 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+                && apt install -y --no-install-recommends \
+                    gnupg2 \
+                    tzdata \
+                    software-properties-common \
+                    libntlm0 \
+                    winbind \
+                    xvfb \
+                    xauth \
+                    python3 \
+                    libncurses5:i386 \
+                    libncurses6:i386 \
+                    libsdl2-2.0-0 \
+                    libsdl2-2.0-0:i386
 
+# Install rcon
 RUN             cd /tmp/ \
                 && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
                 && tar xvf rcon.tar.gz \

--- a/wine/7/Dockerfile
+++ b/wine/7/Dockerfile
@@ -6,11 +6,24 @@ FROM            ghcr.io/parkervcp/yolks:debian
 LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL           org.opencontainers.image.licenses=MIT
 
-## install required packages
+# Install required packages
 RUN             dpkg --add-architecture i386 \
                 && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata software-properties-common libntlm0 winbind xvfb xauth python3 libncurses5:i386 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+                && apt install -y --no-install-recommends \
+                    gnupg2 \
+                    tzdata \
+                    software-properties-common \
+                    libntlm0 \
+                    winbind \
+                    xvfb \
+                    xauth \
+                    python3 \
+                    libncurses5:i386 \
+                    libncurses6:i386 \
+                    libsdl2-2.0-0 \
+                    libsdl2-2.0-0:i386
 
+# Install rcon
 RUN             cd /tmp/ \
                 && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
                 && tar xvf rcon.tar.gz \

--- a/wine/8/Dockerfile
+++ b/wine/8/Dockerfile
@@ -6,11 +6,24 @@ FROM            ghcr.io/parkervcp/yolks:debian
 LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL           org.opencontainers.image.licenses=MIT
 
-## install required packages
+# Install required packages
 RUN             dpkg --add-architecture i386 \
                 && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata software-properties-common libntlm0 winbind xvfb xauth python3 libncurses5:i386 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+                && apt install -y --no-install-recommends \
+                    gnupg2 \
+                    tzdata \
+                    software-properties-common \
+                    libntlm0 \
+                    winbind \
+                    xvfb \
+                    xauth \
+                    python3 \
+                    libncurses5:i386 \
+                    libncurses6:i386 \
+                    libsdl2-2.0-0 \
+                    libsdl2-2.0-0:i386
 
+# Install rcon
 RUN             cd /tmp/ \
                 && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
                 && tar xvf rcon.tar.gz \

--- a/wine/9/Dockerfile
+++ b/wine/9/Dockerfile
@@ -6,11 +6,24 @@ FROM            ghcr.io/parkervcp/yolks:debian
 LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL           org.opencontainers.image.licenses=MIT
 
-## install required packages
+# Install required packages
 RUN             dpkg --add-architecture i386 \
                 && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata software-properties-common libntlm0 winbind xvfb xauth python3 libncurses5:i386 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+                && apt install -y --no-install-recommends \
+                    gnupg2 \
+                    tzdata \
+                    software-properties-common \
+                    libntlm0 \
+                    winbind \
+                    xvfb \
+                    xauth \
+                    python3 \
+                    libncurses5:i386 \
+                    libncurses6:i386 \
+                    libsdl2-2.0-0 \
+                    libsdl2-2.0-0:i386
 
+# Install rcon
 RUN             cd /tmp/ \
                 && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
                 && tar xvf rcon.tar.gz \

--- a/wine/devel/Dockerfile
+++ b/wine/devel/Dockerfile
@@ -6,11 +6,24 @@ FROM            ghcr.io/parkervcp/yolks:debian
 LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL           org.opencontainers.image.licenses=MIT
 
-## install required packages
+# Install required packages
 RUN             dpkg --add-architecture i386 \
                 && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata software-properties-common libntlm0 winbind xvfb xauth python3 libncurses5:i386 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+                && apt install -y --no-install-recommends \
+                    gnupg2 \
+                    tzdata \
+                    software-properties-common \
+                    libntlm0 \
+                    winbind \
+                    xvfb \
+                    xauth \
+                    python3 \
+                    libncurses5:i386 \
+                    libncurses6:i386 \
+                    libsdl2-2.0-0 \
+                    libsdl2-2.0-0:i386
 
+# Install rcon
 RUN             cd /tmp/ \
                 && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
                 && tar xvf rcon.tar.gz \

--- a/wine/entrypoint.sh
+++ b/wine/entrypoint.sh
@@ -25,11 +25,7 @@ fi
 if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then 
     # Update Source Server
     if [ ! -z ${SRCDS_APPID} ]; then
-	    if [ "${STEAM_USER}" == "anonymous" ]; then
-            ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
-	    else
-            numactl --physcpubind=+0 ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
-	    fi
+	./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) $( [[ -z ${VALIDATE} ]] || printf %s "validate" ) +quit
     else
         echo -e "No appid set. Starting Server"
     fi

--- a/wine/latest/Dockerfile
+++ b/wine/latest/Dockerfile
@@ -6,11 +6,24 @@ FROM            ghcr.io/parkervcp/yolks:debian
 LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL           org.opencontainers.image.licenses=MIT
 
-## install required packages
+# Install required packages
 RUN             dpkg --add-architecture i386 \
                 && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata software-properties-common libntlm0 winbind xvfb xauth python3 libncurses5:i386 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+                && apt install -y --no-install-recommends \
+                    gnupg2 \
+                    tzdata \
+                    software-properties-common \
+                    libntlm0 \
+                    winbind \
+                    xvfb \
+                    xauth \
+                    python3 \
+                    libncurses5:i386 \
+                    libncurses6:i386 \
+                    libsdl2-2.0-0 \
+                    libsdl2-2.0-0:i386
 
+# Install rcon
 RUN             cd /tmp/ \
                 && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
                 && tar xvf rcon.tar.gz \

--- a/wine/staging/Dockerfile
+++ b/wine/staging/Dockerfile
@@ -6,11 +6,24 @@ FROM            ghcr.io/parkervcp/yolks:debian
 LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL           org.opencontainers.image.licenses=MIT
 
-## install required packages
+# Install required packages
 RUN             dpkg --add-architecture i386 \
                 && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata software-properties-common libntlm0 winbind xvfb xauth python3 libncurses5:i386 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+                && apt install -y --no-install-recommends \
+                    gnupg2 \
+                    tzdata \
+                    software-properties-common \
+                    libntlm0 \
+                    winbind \
+                    xvfb \
+                    xauth \
+                    python3 \
+                    libncurses5:i386 \
+                    libncurses6:i386 \
+                    libsdl2-2.0-0 \
+                    libsdl2-2.0-0:i386
 
+# Install rcon
 RUN             cd /tmp/ \
                 && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
                 && tar xvf rcon.tar.gz \


### PR DESCRIPTION
## Description

Removed the `numactl` package from all images as SteamCMD no longer seems to have issues logging in with a real Steam account (at least on bookworm, which all these images use).

The following cleanup changes only apply to Dockerfiles that had `numactl` removed. Please feel free to commit additional changes to this branch if you would like to make similar cleanup changes to other Dockerfiles in the repo and group them with this PR.

- Changed all Dockerfiles to use `apt` (instead of `apt-get`) for consistency.
- Changed all `apt install` packages to a "list" format for consistency and easier diff reading for future package additions/removals.
- Added `locales` to `games\source\Dockerfile` and set the locale (similar to `steamcmd\debian\Dockerfile`).
- Moved all instances of the `useradd` command down with the other user and working directory commands. Also  added the shell specification flag if it was missing.
- Unified all Dockerfiles to use space-indenting and fixed some indent spacing.
- Cleaned up some comments.

### All Submissions:

* [ ] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [ ] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [ ] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
2. [ ] Have you updated the README list to contain your new image?
