### PR TITLE
Fallback to default GITHUB_TOKEN, if REGISTRY_TOKEN does not exist

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - apps/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:apps_${{ matrix.app }}"
@@ -30,7 +33,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - oses/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:${{ matrix.oses }}"
@@ -29,7 +32,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./oses/${{ matrix.oses }}

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - bot/**
+permissions:
+  packages: write
+
 jobs:
   pushArm:
     name: "yolks:bot_${{ matrix.tag }}"
@@ -40,7 +43,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./bot/${{ matrix.tag }}
@@ -75,7 +78,7 @@ jobs:
   #       with:
   #         registry: ghcr.io
   #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.REGISTRY_TOKEN }}
+  #         password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
   #     - uses: docker/build-push-action@v6
   #       with:
   #         context: ./bot/${{ matrix.tag }}

--- a/.github/workflows/box64.yml
+++ b/.github/workflows/box64.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - box64/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:${{ matrix.tag }}"
@@ -27,7 +30,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./box64

--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - bun/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:bun_${{ matrix.tag }}"
@@ -28,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./bun

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - cassandra/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:cassandra_${{ matrix.tag }}"
@@ -27,7 +30,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./cassandra

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - dart/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:dart_${{ matrix.tag }}"
@@ -32,7 +35,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./dart

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - dotnet/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:dotnet_${{ matrix.tag }}"
@@ -34,7 +37,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./dotnet

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - elixir/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:elixir_${{ matrix.tag }}"
@@ -31,7 +34,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./elixir

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - erlang/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:erlang_${{ matrix.tag }}"
@@ -30,7 +33,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./erlang

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - games/**
+permissions:
+  packages: write
+
 jobs:
   pushAMD64:
     name: "games_AMD64:${{ matrix.game }}"
@@ -35,7 +38,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./games/${{ matrix.game }}
@@ -67,7 +70,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./games/${{ matrix.game }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - go/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:go_${{ matrix.tag }}"
@@ -35,7 +38,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./go

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - installers/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "installers:{{ matrix.tag }}"
@@ -29,7 +32,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./installers

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - java/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:java_${{ matrix.tag }}"
@@ -36,7 +39,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./java

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -9,6 +9,9 @@ on:
       - master
     paths:
       - mariadb/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:mariadb_${{ matrix.tag }}"
@@ -37,7 +40,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./mariadb

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -9,6 +9,9 @@ on:
       - master
     paths:
       - mongodb/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:mongodb_${{ matrix.tag }}"
@@ -31,7 +34,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./mongodb

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - mono/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:mono_${{ matrix.tag }}"
@@ -26,7 +29,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./mono

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - nodejs/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:nodejs_${{ matrix.tag }}"
@@ -38,7 +41,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./nodejs

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -9,6 +9,9 @@ on:
       - master
     paths:
       - postgres/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:postgres_${{ matrix.tag }}"
@@ -34,7 +37,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./postgres

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - python/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:python_${{ matrix.tag }}"
@@ -35,7 +38,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./python

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -9,6 +9,9 @@ on:
       - master
     paths:
       - redis/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:redis_${{ matrix.tag }}"
@@ -30,7 +33,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./redis

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - rust/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:rust_${{ matrix.tag }}"
@@ -30,7 +33,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./rust

--- a/.github/workflows/steamcmd.yml
+++ b/.github/workflows/steamcmd.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - steamcmd/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "steamcmd:${{ matrix.distro }}"
@@ -31,7 +34,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./steamcmd

--- a/.github/workflows/voice.yml
+++ b/.github/workflows/voice.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - voice/**
+permissions:
+  packages: write
+
 jobs:
   pushx64:
     name: "yolks:voice_${{ matrix.tag }}"
@@ -26,7 +29,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./voice/${{ matrix.tag }}
@@ -58,7 +61,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./voice/${{ matrix.tag }}

--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - wine/**
+permissions:
+  packages: write
+
 jobs:
   push:
     name: "yolks:wine_${{ matrix.tag }}"
@@ -32,7 +35,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: ./wine


### PR DESCRIPTION
(cherry picked from commit aad7d82accd821c07d1683afe82e2c4a103a9858)

## Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

This Repo expects a secret called `REGISTRY_TOKEN` to exist. For Forks it's simpler, if the Workflow can fall-back to `GITHUB_TOKEN`. (I get why this repo uses a REGISTRY_TOKEN though).

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [ ] Have you added your image to the [Github workflows](https://github.com/pelican-eggs/yolks/tree/master/.github/workflows)?
2. [ ] Have you updated the README list to contain your new image?
