### PR TITLE
fix(debian): upgrade libssl1.1

### DIFF
--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -25,10 +25,10 @@ RUN          apt install -y gcc g++ libgcc-12-dev libc++-dev gdb libc6 git wget 
 # Temp fix for libicu66.1 for RAGE-MP and libssl1.1 for fivem and many more
 RUN         if [ "$(uname -m)" = "x86_64" ]; then \
                 wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2.1_amd64.deb && \
-                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb && \
                 dpkg -i libicu66_66.1-2ubuntu2.1_amd64.deb && \
-                dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
-                rm libicu66_66.1-2ubuntu2.1_amd64.deb libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
+                dpkg -i libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb && \
+                rm libicu66_66.1-2ubuntu2.1_amd64.deb libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb; \
             fi
 # ARM64
 RUN         if [ ! "$(uname -m)" = "x86_64" ]; then \


### PR DESCRIPTION
## Description

When downloading a specific version of Minecraft Bedrock (for example: `1.16.0.2`), it throw an error requesting `OPENSSL_1_1_1`.
<img width="817" height="52" alt="image" src="https://github.com/user-attachments/assets/b8e7ec07-21fb-432d-ada8-316ea94740e1" />

Upgrading to a "newer" libssl1.1 fix this problem by adding compatibility of `OPENSSL_1_1_1` in complement of `OPENSSL_1_1_0`.
<img width="539" height="140" alt="image" src="https://github.com/user-attachments/assets/0f35feaa-c5e0-4c88-8408-b0e4304d3822" />

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?