### PR TITLE
[SteamCMD] Entrypoint cleanup & small improvements

### DIFF
--- a/steamcmd/entrypoint.sh
+++ b/steamcmd/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2021 Matthew Penner
+# Copyright (c) 2021 Matthew Penner and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -46,44 +46,38 @@ if [ -f "/usr/local/bin/proton" ]; then
         echo -e "WARNING!!! Proton needs variable SRCDS_APPID, else it will not work. Please add it"
         echo -e "Server stops now"
         echo -e "----------------------------------------------------------------------------------"
-        exit 0
+        exit 1
         fi
 fi
 
 # Switch to the container's working directory
 cd /home/container || exit 1
 
-## just in case someone removed the defaults.
-if [ "${STEAM_USER}" == "" ]; then
-    echo -e "steam user is not set.\n"
-    echo -e "Using anonymous user.\n"
-    STEAM_USER=anonymous
-    STEAM_PASS=""
-    STEAM_AUTH=""
-else
-    echo -e "user set to ${STEAM_USER}"
-fi
-
-## if auto_update is not set or to 1 update
-if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then 
-    # Update Source Server
+## Update server via SteamCMD if AUTO_UPDATE is 1 or not set
+if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then
+    echo -e "Checking for game server updates..."
+    # Check for set App ID
     if [ ! -z ${SRCDS_APPID} ]; then
-	    if [ "${STEAM_USER}" == "anonymous" ]; then
-            ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" )  ${INSTALL_FLAGS} $( [[ "${VALIDATE}" == "1" ]] && printf %s 'validate' ) +quit
-	    else
-            ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) ${INSTALL_FLAGS} $( [[ "${VALIDATE}" == "1" ]] && printf %s 'validate' ) +quit
-	    fi
+        # Set default credentials if they are missing
+        if [ "${STEAM_USER}" == "" ]; then
+            echo -e "Steam user is not set. Defaulting to anonymous user."
+            STEAM_USER=anonymous
+            STEAM_PASS=""
+            STEAM_AUTH=""
+        fi
+        # Run SteamCMD
+        ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update 1007 +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) ${INSTALL_FLAGS} $( [[ "${VALIDATE}" == "1" ]] && printf %s 'validate' ) +quit
     else
-        echo -e "No appid set. Starting Server"
+        echo -e "No App ID set! Skipping check."
     fi
-
 else
-    echo -e "Not updating game server as auto update was set to 0. Starting Server"
+    echo -e "Skipping game server update check; Auto Update is set to 0."
 fi
 
 # Replace Startup Variables
-MODIFIED_STARTUP=$(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
-echo -e ":/home/container$ ${MODIFIED_STARTUP}"
+modifiedStartup=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 
 # Run the Server
-eval ${MODIFIED_STARTUP}
+echo -e "Starting server..."
+echo -e ":/home/container$ ${modifiedStartup}"
+${modifiedStartup}


### PR DESCRIPTION
## Description

- Changed exit code for Proton error from 0 to 1 (0 wrongly indicates success).
- Moved default Steam credentials check block into auto update block (ie. only check and adjust if actually updating).
- Removed redundant Steam user "anonymous" check (SteamCMD call was the same in either case).
- Improved verbiage of comments and prints.
- Improved modified startup print accuracy. Previously, certain characters (namely quotes) would not print in the `echo` statement, even though they were technically there during `eval`.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
