### PR TITLE
Workflow changes to ARM instead of QEMU emulation

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -12,39 +12,87 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:apps_${{ matrix.app }}"
+  build:
+    name: "build:apps_${{ matrix.app }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        app:
+          - uptimekuma
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
+        with:
+          context: ./apps/${{ matrix.app }}
+          file: ./apps/${{ matrix.app }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/apps:{0}-{1}', matrix.app, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: steps.build.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./apps/${{ matrix.app }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }}-${{ matrix.config.platform_suffix }} \
+              ./apps/${{ matrix.app }}
+
+  merge:
+    name: "merge:apps_${{ matrix.app }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
         app:
           - uptimekuma
     steps:
-      - uses: actions/checkout@v4
-      
-      - uses: docker/setup-qemu-action@v3
-      
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
-      
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./apps/${{ matrix.app }}
-          file: ./apps/${{ matrix.app }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/apps:{0}', matrix.app) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/apps:${{ matrix.app }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/apps:${{ matrix.app }}-arm64

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -12,9 +12,66 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:${{ matrix.oses }}"
+  build:
+    name: "build:oses_${{ matrix.oses }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        oses:
+          - alpine
+          - debian
+          - ubuntu
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
+        with:
+          context: ./oses/${{ matrix.oses }}
+          file: ./oses/${{ matrix.oses }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:{0}-{1}', matrix.oses, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: steps.build.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./oses/${{ matrix.oses }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }}-${{ matrix.config.platform_suffix }} \
+              ./oses/${{ matrix.oses }}
+
+  merge:
+    name: "merge:oses_${{ matrix.oses }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -23,26 +80,23 @@ jobs:
           - debian
           - ubuntu
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./oses/${{ matrix.oses }}
-          file: ./oses/${{ matrix.oses }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:{0}', matrix.oses) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:${{ matrix.oses }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.oses }}-arm64

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -12,9 +12,65 @@ permissions:
   packages: write
 
 jobs:
-  pushArm:
-    name: "yolks:bot_${{ matrix.tag }}"
+  build:
+    name: "build:bot_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - parkertron
+          - red
+          - sinusbot
+          - bastion
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./bot/${{ matrix.tag }}
+          file: ./bot/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:bot_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./bot/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./bot/${{ matrix.tag }}
+
+  merge:
+    name: "merge:bot_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -24,70 +80,23 @@ jobs:
           - sinusbot
           - bastion
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,amd64
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./bot/${{ matrix.tag }}
-          file: ./bot/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:bot_{0}', matrix.tag) || '' }}
-      - name: Move cache
+      - name: Create multi-arch manifest
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-  # pushAmd:
-  #   name: "yolks:bot_${{ matrix.tag }}"
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       tag:
-  #         - bastion
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: docker/setup-buildx-action@v1
-  #       with:
-  #         version: "v0.7.0"
-  #         buildkitd-flags: --debug
-  #     - uses: docker/login-action@v1
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ steps.lower-repo.outputs.repository }}
-  #         password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-  #     - uses: docker/build-push-action@v6
-  #       with:
-  #         context: ./bot/${{ matrix.tag }}
-  #         file: ./bot/${{ matrix.tag }}/Dockerfile
-  #         platforms: linux/amd64
-  #         push: true
-  #         tags: |
-  #           ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:bot_{0}', matrix.tag) || '' }}
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:bot_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bot_${{ matrix.tag }}-arm64

--- a/.github/workflows/box64.yml
+++ b/.github/workflows/box64.yml
@@ -14,28 +14,27 @@ permissions:
 jobs:
   push:
     name: "yolks:${{ matrix.tag }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         tag:
           - box64
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./box64
           file: ./${{ matrix.tag }}/Dockerfile
@@ -44,3 +43,16 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.tag }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:{0}', matrix.tag) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./${{ matrix.tag }}/Dockerfile \
+              --platform linux/arm64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:${{ matrix.tag }} \
+              ./box64

--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -12,9 +12,65 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:bun_${{ matrix.tag }}"
+  build:
+    name: "build:bun_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - latest
+          - canary
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
+        with:
+          context: ./bun
+          file: ./bun/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:bun_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: steps.build.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./bun/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./bun
+
+  merge:
+    name: "merge:bun_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -22,26 +78,23 @@ jobs:
           - latest
           - canary
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./bun
-          file: ./bun/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:bun_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:bun_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:bun_${{ matrix.tag }}-arm64

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -22,20 +22,20 @@ jobs:
           - java8_python2
           - java11_python3
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./cassandra
           file: ./cassandra/${{ matrix.tag }}/Dockerfile
@@ -44,3 +44,16 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:cassandra_${{ matrix.tag }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:cassandra_{0}', matrix.tag) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./cassandra/${{ matrix.tag }}/Dockerfile \
+              --platform linux/amd64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:cassandra_${{ matrix.tag }} \
+              ./cassandra

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,9 +12,68 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:dart_${{ matrix.tag }}"
+  build:
+    name: "build:dart_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - '2.17'
+          - '2.18'
+          - '2.19'
+          - '3.3'
+          - stable
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
+        with:
+          context: ./dart
+          file: ./dart/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:dart_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: steps.build.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./dart/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./dart
+
+  merge:
+    name: "merge:dart_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -23,29 +82,25 @@ jobs:
           - '2.18'
           - '2.19'
           - '3.3'
-          - 'stable'
+          - stable
     steps:
-      - uses: actions/checkout@v4
-      # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./dart
-          file: ./dart/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:dart_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:dart_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dart_${{ matrix.tag }}-arm64

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,9 +12,71 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:dotnet_${{ matrix.tag }}"
+  build:
+    name: "build:dotnet_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - 2.1
+          - 3.1
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - '10'
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
+        with:
+          context: ./dotnet
+          file: ./dotnet/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:dotnet_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: steps.build.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./dotnet/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./dotnet
+
+  merge:
+    name: "merge:dotnet_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -28,27 +90,23 @@ jobs:
           - 9
           - '10'
     steps:
-      - uses: actions/checkout@v4
-            # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./dotnet
-          file: ./dotnet/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:dotnet_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:dotnet_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:dotnet_${{ matrix.tag }}-arm64

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,9 +12,66 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:elixir_${{ matrix.tag }}"
+  build:
+    name: "build:elixir_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - '1.15'
+          - '1.14'
+          - '1.13'
+          - '1.12'
+          - latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./elixir
+          file: ./elixir/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:elixir_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./elixir/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./elixir
+
+  merge:
+    name: "merge:elixir_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -25,26 +82,23 @@ jobs:
           - '1.12'
           - latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./elixir
-          file: ./elixir/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:elixir_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:elixir_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:elixir_${{ matrix.tag }}-arm64

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -25,20 +25,20 @@ jobs:
           - 25
           - 26
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./erlang
           file: ./erlang/${{ matrix.tag }}/Dockerfile
@@ -47,3 +47,16 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:erlang_${{ matrix.tag }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:erlang_{0}', matrix.tag) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./erlang/${{ matrix.tag }}/Dockerfile \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:erlang_${{ matrix.tag }} \
+              ./erlang

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -68,9 +68,6 @@ jobs:
               --push \
               --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }} \
               ./games/${{ matrix.game }}
-      - name: Check build outcome
-        if: always() && steps.build.outcome == 'failure'
-        run: exit 1
 
   build:
     name: "games_build:${{ matrix.game }} (${{ matrix.config.platform }})"
@@ -127,9 +124,6 @@ jobs:
               --push \
               --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-${{ matrix.config.platform_suffix }} \
               ./games/${{ matrix.game }}
-      - name: Check build outcome
-        if: always() && steps.build.outcome == 'failure'
-        run: exit 1
 
   merge:
     name: "games_merge:${{ matrix.game }}"

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -31,20 +31,20 @@ jobs:
           - zandronum
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./games/${{ matrix.game }}
           file: ./games/${{ matrix.game }}/Dockerfile
@@ -53,9 +53,78 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/games:{0}', matrix.game) || '' }}
-  pushAll:
-    name: "games_All:${{ matrix.game }}"
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./games/${{ matrix.game }}/Dockerfile \
+              --platform linux/amd64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }} \
+              ./games/${{ matrix.game }}
+
+  build:
+    name: "games_build:${{ matrix.game }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        game:
+          - minetest
+          - mta
+          - hytale
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./games/${{ matrix.game }}
+          file: ./games/${{ matrix.game }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/games:{0}-{1}', matrix.game, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./games/${{ matrix.game }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-${{ matrix.config.platform_suffix }} \
+              ./games/${{ matrix.game }}
+
+  merge:
+    name: "games_merge:${{ matrix.game }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -64,29 +133,23 @@ jobs:
           - mta
           - hytale
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,amd64
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./games/${{ matrix.game }}
-          file: ./games/${{ matrix.game }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/games:{0}', matrix.game) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/games:${{ matrix.game }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-arm64

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -45,6 +45,8 @@ jobs:
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
         with:
           context: ./games/${{ matrix.game }}
           file: ./games/${{ matrix.game }}/Dockerfile
@@ -54,7 +56,7 @@ jobs:
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/games:{0}', matrix.game) || '' }}
       - name: Retry build
-        if: failure()
+        if: steps.build.outcome == 'failure'
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 20
@@ -66,6 +68,9 @@ jobs:
               --push \
               --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }} \
               ./games/${{ matrix.game }}
+      - name: Check build outcome
+        if: always() && steps.build.outcome == 'failure'
+        run: exit 1
 
   build:
     name: "games_build:${{ matrix.game }} (${{ matrix.config.platform }})"
@@ -99,6 +104,8 @@ jobs:
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
         with:
           context: ./games/${{ matrix.game }}
           file: ./games/${{ matrix.game }}/Dockerfile
@@ -108,7 +115,7 @@ jobs:
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-${{ matrix.config.platform_suffix }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/games:{0}-{1}', matrix.game, matrix.config.platform_suffix) || '' }}
       - name: Retry build
-        if: failure()
+        if: steps.build.outcome == 'failure'
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 20
@@ -120,6 +127,9 @@ jobs:
               --push \
               --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/games:${{ matrix.game }}-${{ matrix.config.platform_suffix }} \
               ./games/${{ matrix.game }}
+      - name: Check build outcome
+        if: always() && steps.build.outcome == 'failure'
+        run: exit 1
 
   merge:
     name: "games_merge:${{ matrix.game }}"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,20 +30,20 @@ jobs:
           - '1.22'
           - '1.23'
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./go
           file: ./go/${{ matrix.tag }}/Dockerfile
@@ -52,3 +52,16 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:go_${{ matrix.tag }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:go_{0}', matrix.tag) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./go/${{ matrix.tag }}/Dockerfile \
+              --platform linux/amd64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:go_${{ matrix.tag }} \
+              ./go

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -12,9 +12,69 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "installers:${{ matrix.tag }}"
+  build:
+    name: "build:installers_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - alpine
+          - debian
+          - ubuntu
+          - java_8
+          - java_11
+          - java_17
+          - java_21
+          - java_25
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./installers
+          file: ./installers/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/installers:{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./installers/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./installers
+
+  merge:
+    name: "merge:installers_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -28,26 +88,23 @@ jobs:
           - java_21
           - java_25
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./installers
-          file: ./installers/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/installers:{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/installers:${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/installers:${{ matrix.tag }}-arm64

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -12,19 +12,23 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:java_${{ matrix.tag }}"
-    runs-on: ubuntu-latest
+  build:
+    name: "build:java_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
         tag:
           - 8
-#          - 8j9
           - 11
-#          - 11j9
           - 16
-#          - 16j9
           - 17
           - 19
           - 21
@@ -32,26 +36,77 @@ jobs:
           - 25
           - 26
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./java
           file: ./java/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.config.platform }}
           push: true
           tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:java_{0}', matrix.tag) || '' }}
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:java_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./java/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./java
+
+  merge:
+    name: "merge:java_${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - 8
+          - 11
+          - 16
+          - 17
+          - 19
+          - 21
+          - 22
+          - 25
+          - 26
+    steps:
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:java_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:java_${{ matrix.tag }}-arm64

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -1,6 +1,5 @@
 name: build mariadb
 on:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 1"
@@ -13,9 +12,71 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:mariadb_${{ matrix.tag }}"
+  build:
+    name: "build:mariadb_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - '10.3'
+          - '10.4'
+          - '10.5'
+          - '10.6'
+          - '10.7'
+          - '11.2'
+          - '11.3'
+          - '11.4'
+          - '11.5'
+          - '11.6'
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./mariadb
+          file: ./mariadb/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:mariadb_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./mariadb/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./mariadb
+
+  merge:
+    name: "merge:mariadb_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -31,26 +92,23 @@ jobs:
           - '11.5'
           - '11.6'
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./mariadb
-          file: ./mariadb/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:mariadb_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:mariadb_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mariadb_${{ matrix.tag }}-arm64

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -1,6 +1,5 @@
 name: build mongodb
 on:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 1"
@@ -13,38 +12,89 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:mongodb_${{ matrix.tag }}"
-    runs-on: ubuntu-latest
+  build:
+    name: "build:mongodb_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
         tag:
-          - 5
           - 6
           - 7
           - 8
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./mongodb
           file: ./mongodb/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.config.platform }}
           push: true
           tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:mongodb_{0}', matrix.tag) || '' }}
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:mongodb_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./mongodb/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./mongodb
+
+  merge:
+    name: "merge:mongodb_${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - 6
+          - 7
+          - 8
+    steps:
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:mongodb_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mongodb_${{ matrix.tag }}-arm64

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -21,20 +21,20 @@ jobs:
         tag:
           - latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./mono
           file: ./mono/${{ matrix.tag }}/Dockerfile
@@ -43,3 +43,16 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mono_${{ matrix.tag }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:mono_{0}', matrix.tag) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./mono/${{ matrix.tag }}/Dockerfile \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:mono_${{ matrix.tag }} \
+              ./mono

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,19 +12,20 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:nodejs_${{ matrix.tag }}"
-    runs-on: ubuntu-latest
+  build:
+    name: "build:nodejs_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
         tag:
-#          - 12
-#          - 14
-#          - 16
-#          - 17
-#          - 18
-#          - 19
           - 20
           - 21
           - 22
@@ -32,27 +33,76 @@ jobs:
           - 24
           - 25
     steps:
-      - uses: actions/checkout@v4
-      # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
         with:
           context: ./nodejs
           file: ./nodejs/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.config.platform }}
           push: true
           tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:nodejs_{0}', matrix.tag) || '' }}
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:nodejs_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: steps.build.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./nodejs/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./nodejs
+
+  merge:
+    name: "merge:nodejs_${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - 20
+          - 21
+          - 22
+          - 23
+          - 24
+          - 25
+    steps:
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:nodejs_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:nodejs_${{ matrix.tag }}-arm64

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -13,9 +13,70 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:postgres_${{ matrix.tag }}"
+  build:
+    name: "build:postgres_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 16
+          - 17
+          - 18
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./postgres
+          file: ./postgres/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:postgres_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./postgres/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./postgres
+
+  merge:
+    name: "merge:postgres_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -30,26 +91,23 @@ jobs:
           - 17
           - 18
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./postgres
-          file: ./postgres/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:postgres_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:postgres_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:postgres_${{ matrix.tag }}-arm64

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,14 +12,20 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:python_${{ matrix.tag }}"
-    runs-on: ubuntu-latest
+  build:
+    name: "build:python_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
         tag:
-          - '2.7'
           - '3.7'
           - '3.8'
           - '3.9'
@@ -29,27 +35,78 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v4
-      # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
+        id: build
+        continue-on-error: true
         with:
           context: ./python
           file: ./python/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.config.platform }}
           push: true
           tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:python_{0}', matrix.tag) || '' }}
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:python_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: steps.build.outcome == 'failure'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./python/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./python
+
+  merge:
+    name: "merge:python_${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+    steps:
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:python_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:python_${{ matrix.tag }}-arm64

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -1,6 +1,5 @@
 name: build redis
 on:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 1"
@@ -13,9 +12,65 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:redis_${{ matrix.tag }}"
+  build:
+    name: "build:redis_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - 5
+          - 6
+          - 7
+          - 8
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./redis
+          file: ./redis/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:redis_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./redis/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./redis
+
+  merge:
+    name: "merge:redis_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -25,26 +80,23 @@ jobs:
           - 7
           - 8
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./redis
-          file: ./redis/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:redis_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:redis_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:redis_${{ matrix.tag }}-arm64

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,38 +12,89 @@ permissions:
   packages: write
 
 jobs:
-  push:
-    name: "yolks:rust_${{ matrix.tag }}"
-    runs-on: ubuntu-latest
+  build:
+    name: "build:rust_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
         tag:
           - '1.56'
           - '1.60'
-          - 'latest'
+          - latest
     steps:
-      - uses: actions/checkout@v4
-      # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v3          
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./rust
           file: ./rust/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.config.platform }}
           push: true
           tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:rust_{0}', matrix.tag) || '' }}
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:rust_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./rust/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./rust
+
+  merge:
+    name: "merge:rust_${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - '1.56'
+          - '1.60'
+          - latest
+    steps:
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:rust_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:rust_${{ matrix.tag }}-arm64

--- a/.github/workflows/steamcmd.yml
+++ b/.github/workflows/steamcmd.yml
@@ -26,20 +26,20 @@ jobs:
           - proton_8   
           - sniper
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./steamcmd
           file: ./steamcmd/${{ matrix.distro }}/Dockerfile
@@ -48,3 +48,16 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/steamcmd:${{ matrix.distro }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/steamcmd:{0}', matrix.distro) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./steamcmd/${{ matrix.distro }}/Dockerfile \
+              --platform linux/amd64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/steamcmd:${{ matrix.distro }} \
+              ./steamcmd

--- a/.github/workflows/voice.yml
+++ b/.github/workflows/voice.yml
@@ -21,20 +21,20 @@ jobs:
         tag:
           - teaspeak
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./voice/${{ matrix.tag }}
           file: ./voice/${{ matrix.tag }}/Dockerfile
@@ -43,39 +43,99 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:voice_{0}', matrix.tag) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./voice/${{ matrix.tag }}/Dockerfile \
+              --platform linux/amd64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }} \
+              ./voice/${{ matrix.tag }}
 
+  build:
+    name: "build:voice_${{ matrix.tag }} (${{ matrix.config.platform }})"
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - platform: linux/amd64
+            platform_suffix: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_suffix: arm64
+            runner: ubuntu-24.04-arm
+        tag:
+          - mumble
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --debug
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ steps.lower-repo.outputs.repository }}
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./voice/${{ matrix.tag }}
+          file: ./voice/${{ matrix.tag }}/Dockerfile
+          platforms: ${{ matrix.config.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}-${{ matrix.config.platform_suffix }}
+            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:voice_{0}-{1}', matrix.tag, matrix.config.platform_suffix) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./voice/${{ matrix.tag }}/Dockerfile \
+              --platform ${{ matrix.config.platform }} \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}-${{ matrix.config.platform_suffix }} \
+              ./voice/${{ matrix.tag }}
 
-  pushx64_arm64:
-    name: "yolks:voice_${{ matrix.tag }}"
+  merge:
+    name: "merge:voice_${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
         tag:
           - mumble
     steps:
-      - uses: actions/checkout@v4
-      # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v3      
-      - uses: docker/setup-buildx-action@v3
-        with:
-          version: "v0.8.2"
-          buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./voice/${{ matrix.tag }}
-          file: ./voice/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}
-            ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:voice_{0}', matrix.tag) || '' }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}-arm64
+      - name: Create pelican-eggs tag
+        if: github.repository_owner == 'pelican-eggs'
+        run: |
+          docker buildx imagetools create -t ghcr.io/parkervcp/yolks:voice_${{ matrix.tag }} \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:voice_${{ matrix.tag }}-arm64

--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -28,20 +28,20 @@ jobs:
           - devel
           - staging
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
       - id: lower-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ steps.lower-repo.outputs.repository }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./wine
           file: ./wine/${{ matrix.tag }}/Dockerfile
@@ -50,3 +50,16 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:wine_${{ matrix.tag }}
             ${{ github.repository_owner == 'pelican-eggs' && format('ghcr.io/parkervcp/yolks:wine_{0}', matrix.tag) || '' }}
+      - name: Retry build
+        if: failure()
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            docker buildx build \
+              --file ./wine/${{ matrix.tag }}/Dockerfile \
+              --platform linux/amd64 \
+              --push \
+              --tag ghcr.io/${{ steps.lower-repo.outputs.repository }}/yolks:wine_${{ matrix.tag }} \
+              ./wine


### PR DESCRIPTION
## Description

I noticed the failing workflow runs and implemented following changes:
- Migration to ARM Github Runners (ubuntu-24.04-arm) instead of QEMU emulation on amd64.     https://docs.github.com/en/actions/reference/runners/github-hosted-runners                                                                                                                   
- Bumped GitHub Actions for actions/checkout@v5, docker/setup-buildx-action@v4, docker/login-action@v4, docker/build-push-action@v7, nick-fields/retry@v3 
- We use Node24 (EOL of Node20 was in April 2026) https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- Added ARM builds for missing workflows
- Added retry logic to handle network failures.                 
- Removed Python 2.7 and MongoDB 5 due to expired keys

See workflow runs on https://github.com/Xytronix/yolks/actions
                                                                                               
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
