### PR TITLE
[Arma 3] Add libavahi to Arma 3 Dockerfile

### DIFF
--- a/games/arma3/Dockerfile
+++ b/games/arma3/Dockerfile
@@ -17,6 +17,7 @@ RUN         dpkg --add-architecture i386 \
                 iproute2 \
                 gettext-base \
                 ca-certificates \
+                libavahi-client3 \
                 libssl-dev \
                 lib32gcc-s1 \
                 libsdl2-2.0-0 \


### PR DESCRIPTION
## Description

Added missing Avahi runtime dependencies for Linux Dedicated Server

Since Perf/Prof build v78, the Arma 3 Dedicated Server dynamically links against libavahi-client for ipv6/mDNS support.
The debian slim base image does not ship with avahi by default, which causes the server to fail on startup

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?